### PR TITLE
Add durable_set for workflow dedup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,10 @@ This Rails app uses a small set of preferred libraries for common integration wo
 - `lib/r3x/trigger_manager.rb` + `lib/r3x/trigger_manager/`: trigger infrastructure — `R3x::TriggerManager::Collection` (manages workflow triggers as a hash keyed by `unique_key`) and `R3x::TriggerManager::Execution` (wraps a trigger for runtime use).
 - `app/lib/r3x/`: runtime support code such as client wrappers and shared concerns.
 - `app/lib/r3x/client/victoria_logs.rb`: thin VictoriaLogs HTTP client used by the dashboard when log viewing is enabled.
-- `app/lib/r3x/client/google/credentials.rb`: shared Google credentials loader used by Gmail and Google Sheets integrations.
+- `app/lib/r3x/client/google/credentials.rb`: shared Google credentials loader used by Gmail, Google Sheets, and Google Translate integrations.
 - `lib/r3x/gem_loader.rb`: tiny helper for one-time lazy `require` of heavy optional gems used by integrations and workflow helpers.
 - `app/lib/r3x/client/google/gmail.rb`: Gmail API client used by workflows via `ctx.client.gmail(...)`.
+- `app/lib/r3x/client/google/translate.rb`: Google Translate client used by workflows via `ctx.client.google_translate(...)`.
 - `lib/r3x/workflow/llm_schema.rb`: lazy wrapper around `RubyLLM::Schema` for workflows that need structured LLM output.
 - `R3x::Client::Google` is a project namespace; when referencing the third-party Google gem namespace, use `::Google` to avoid constant collisions.
 - `app/jobs/r3x/`: job entrypoints, especially `R3x::RunWorkflowJob`, which resolves a workflow key and dispatches to the workflow job class, and `R3x::ChangeDetectionJob`, which evaluates change-detecting triggers before enqueueing workflow runs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,11 @@ This Rails app uses a small set of preferred libraries for common integration wo
 - Workflows subclass `R3x::Workflow::Base`, declare triggers via the DSL, and implement `#run`.
 - Workflow code can define structured LLM schemas via `R3x::Workflow::LlmSchema.define { ... }`, which lazy-loads `ruby_llm-schema` instead of requiring it for all processes at boot.
 - `R3x::Workflow::Base` is also an `ApplicationJob`; its `#perform` delegates trigger/context setup to `R3x::Workflow::Executor`, stores the context on the job, and then calls `#run` on the current job instance.
-- Workflow code can use `ctx.durable_set(name = :default, ttl: 60.days)` to get a durable,
+- Workflow code can use `ctx.durable_set(name = :default, ttl: 90.days)` to get a durable,
   workflow-scoped set for best-effort cross-run dedup of processed items.
+- When the app uses `:solid_cache_store`, keep `durable_set` `ttl:` at or below
+  `config/cache.yml` `store_options.max_age` so cache retention does not silently shorten the
+  dedup window.
 - Workflow-declared DSL objects must validate themselves before being registered; invalid DSL configuration should raise `R3x::ConfigurationError` with collected validation errors.
 - `R3x::Workflow::PackLoader` discovers workflow entrypoints named `workflow.rb` from directories listed in `R3X_WORKFLOW_PATHS`, loads them, and registers their classes in `R3x::Workflow::Registry`.
 - `R3x::RecurringTasksConfig` turns schedulable workflow triggers into Solid Queue dynamic recurring tasks via `SolidQueue::RecurringTask`. All triggers have a `unique_key` (based on type + options hash) used for identification and duplicate detection. `schedule_all!` persists dynamic tasks and sweeps stale ones.
@@ -268,6 +271,8 @@ This repo uses `.githooks/` directory for git hooks. The pre-commit hook runs `b
 - Prefer capability-based APIs over branching on symbolic types when behavior can be expressed through an object interface.
 - **Good**: `triggers.select(&:cron_schedulable?)`
 - **Bad**: `triggers.select { |t| t.type == :schedule }`
+- Prefer instance variables only for state the object needs across method calls or as part of its long-lived identity.
+- Do not keep one-time derived configuration in instance variables when it is only used during initialization or validation; keep it local or behind a small helper method instead.
 - When multiple classes share a capability, extract a small concern or module with an explicit predicate and required methods.
 - **Good**: `include R3x::Triggers::Concerns::CronSchedulable`
 - Framework code should avoid hardcoding knowledge of concrete subtypes. Prefer polymorphism, capability predicates, and object-owned methods like `to_h`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@ This Rails app uses a small set of preferred libraries for common integration wo
 - `workflows/`: user workflow packs. These are not the framework itself; they are loaded by the framework.
 - `workflows/<pack>/test/`: self-contained tests for a specific workflow pack. Keep pack-local tests beside the workflow code, and use `test/fixtures/workflows/` for framework-level fixtures.
 - `lib/r3x/workflow/boot.rb`: explicit workflow boot helper used by process entrypoints.
+- `lib/r3x/workflow/durable_set.rb`: workflow-scoped durable set backed by `Rails.cache`, intended
+  for remembering processed item keys across workflow runs.
 - `test/fixtures/workflows/`: fixture workflows for framework tests. Prefer these over hardcoding real workflows in tests.
 
 ## Runtime Flow
@@ -47,6 +49,8 @@ This Rails app uses a small set of preferred libraries for common integration wo
 - Workflows subclass `R3x::Workflow::Base`, declare triggers via the DSL, and implement `#run`.
 - Workflow code can define structured LLM schemas via `R3x::Workflow::LlmSchema.define { ... }`, which lazy-loads `ruby_llm-schema` instead of requiring it for all processes at boot.
 - `R3x::Workflow::Base` is also an `ApplicationJob`; its `#perform` delegates trigger/context setup to `R3x::Workflow::Executor`, stores the context on the job, and then calls `#run` on the current job instance.
+- Workflow code can use `ctx.durable_set(name = :default, ttl: 60.days)` to get a durable,
+  workflow-scoped set for best-effort cross-run dedup of processed items.
 - Workflow-declared DSL objects must validate themselves before being registered; invalid DSL configuration should raise `R3x::ConfigurationError` with collected validation errors.
 - `R3x::Workflow::PackLoader` discovers workflow entrypoints named `workflow.rb` from directories listed in `R3X_WORKFLOW_PATHS`, loads them, and registers their classes in `R3x::Workflow::Registry`.
 - `R3x::RecurringTasksConfig` turns schedulable workflow triggers into Solid Queue dynamic recurring tasks via `SolidQueue::RecurringTask`. All triggers have a `unique_key` (based on type + options hash) used for identification and duplicate detection. `schedule_all!` persists dynamic tasks and sweeps stale ones.

--- a/app/lib/r3x/client/google/translate.rb
+++ b/app/lib/r3x/client/google/translate.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module R3x
+  module Client
+    module Google
+      class Translate
+        API_URL = "https://translation.googleapis.com/language/translate/v2"
+        OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-translation"
+
+        def initialize(credentials_env:)
+          @credentials_env = credentials_env
+        end
+
+        def translate(text, to:, from: nil, format: "text")
+          input = text.to_s
+          return input if input.empty?
+
+          response = connection.post(API_URL, request_body(input, to: to, from: from, format: format), authorization_header)
+          translation = Array(response.body.dig("data", "translations")).first ||
+            raise(ArgumentError, "Missing translations in Google Translate response")
+          translation.fetch("translatedText")
+        end
+
+        private
+
+        attr_reader :credentials_env
+
+        def authorization
+          @authorization ||= R3x::Client::GoogleAuth.from_json(
+            R3x::Client::Google::Credentials.from_env(credentials_env),
+            scope: OAUTH_SCOPE
+          )
+        end
+
+        def authorization_header
+          {
+            "Authorization" => "Bearer #{access_token}"
+          }
+        end
+
+        def access_token
+          authorization.fetch_access_token! if authorization.access_token.nil? || authorization.expires_within?(30)
+          authorization.access_token
+        end
+
+        def connection
+          @connection ||= Faraday.new do |f|
+            f.request :json
+            f.response :json
+            f.response :raise_error
+          end
+        end
+
+        def request_body(text, to:, from:, format:)
+          {
+            q: text,
+            target: to,
+            source: from,
+            format: format
+          }.compact
+        end
+      end
+    end
+  end
+end

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,7 +1,7 @@
 default: &default
   store_options:
-    # Cap age of oldest cache entry to fulfill retention policies
-    max_age: <%= 1.day.to_i %>
+    # Cap age of oldest cache entry to fulfill retention policies and durable dedup defaults.
+    max_age: <%= 90.days.to_i %>
     max_size: <%= 256.megabytes %>
     namespace: <%= Rails.env %>
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -54,6 +54,15 @@ These notes apply to workflow code in general.
   - `R3X_SKIP_CACHE=true` does the same override at the env level.
   - In production, `with_cache` still raises by default unless `R3X_SKIP_CACHE=true` is set.
   - Use `with_cache(force: true)` when you need to refresh a stale cached value.
+- `ctx.durable_set(name = :default, ttl: 60.days)`
+  - Returns a workflow-scoped durable set backed by `Rails.cache`.
+  - Good for remembering which items were already processed, sent, uploaded, or otherwise handled
+    across workflow runs.
+  - Members are scoped by workflow key and set name, so different workflows and different sets do
+    not collide.
+  - Use `include?`, `add`, and `delete` on the returned set.
+  - Prefer this for best-effort dedup across runs; prefer a real table only when you need permanent
+    history or hard uniqueness guarantees.
 
 ## Fail Fast
 
@@ -64,10 +73,13 @@ These notes apply to workflow code in general.
 ## Debugging And Caching
 
 - Prefer `with_cache` only around clearly expensive or noisy calls, not around the whole workflow.
+- Prefer `ctx.durable_set` for cross-run item dedup, not `with_cache`.
 - The normal workflow is:
   - add `with_cache` around the slowest boundary while iterating
   - use `bin/workflow run --skip-cache <path>` when you want a fresh uncached run
   - leave the helper in place if it remains useful for future debugging
+- For durable dedup, use a stable member key from the item itself, such as a URL digest or external
+  post ID, and add it only after the relevant side effect succeeds.
 - If a cached block becomes confusing or hides too much behavior, remove it instead of stacking more
   flags or conditions around it.
 - When a workflow suddenly sees a boolean or `nil` where an array should be, inspect the nearest

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -54,12 +54,14 @@ These notes apply to workflow code in general.
   - `R3X_SKIP_CACHE=true` does the same override at the env level.
   - In production, `with_cache` still raises by default unless `R3X_SKIP_CACHE=true` is set.
   - Use `with_cache(force: true)` when you need to refresh a stale cached value.
-- `ctx.durable_set(name = :default, ttl: 60.days)`
+- `ctx.durable_set(name = :default, ttl: 90.days)`
   - Returns a workflow-scoped durable set backed by `Rails.cache`.
   - Good for remembering which items were already processed, sent, uploaded, or otherwise handled
     across workflow runs.
   - Members are scoped by workflow key and set name, so different workflows and different sets do
     not collide.
+  - When the app uses `:solid_cache_store`, custom `ttl:` values must not exceed
+    `config/cache.yml` `store_options.max_age`.
   - Use `include?`, `add`, and `delete` on the returned set.
   - Prefer this for best-effort dedup across runs; prefer a real table only when you need permanent
     history or hard uniqueness guarantees.

--- a/lib/r3x/workflow/context.rb
+++ b/lib/r3x/workflow/context.rb
@@ -5,16 +5,21 @@ module R3x
     class Context
       include R3x::Concerns::Logger
 
-      attr_reader :trigger, :execution, :workflow_class
+      attr_reader :trigger, :execution, :workflow_class, :workflow_key
 
       def initialize(trigger:, workflow_key:, workflow_class: nil)
         @trigger = trigger
+        @workflow_key = workflow_key
         @workflow_class = workflow_class
         @execution = Execution.new(workflow_key: workflow_key)
       end
 
       def client
         @client ||= Client
+      end
+
+      def durable_set(name = :default, ttl: DurableSet::DEFAULT_TTL)
+        DurableSet.new(workflow_key: workflow_key, name: name, ttl: ttl)
       end
     end
   end

--- a/lib/r3x/workflow/context/client.rb
+++ b/lib/r3x/workflow/context/client.rb
@@ -34,6 +34,10 @@ module R3x
           R3x::Client::Google::Gmail.new(credentials_env: credentials_env)
         end
 
+        def google_translate(credentials_env:)
+          R3x::Client::Google::Translate.new(credentials_env: credentials_env)
+        end
+
         def discord(webhook_url_env:)
           R3x::Client::Discord.new(webhook_url_env: webhook_url_env)
         end

--- a/lib/r3x/workflow/durable_set.rb
+++ b/lib/r3x/workflow/durable_set.rb
@@ -5,12 +5,14 @@ require "digest"
 module R3x
   module Workflow
     class DurableSet
-      DEFAULT_TTL = 60.days
+      DEFAULT_TTL = 90.days
 
       def initialize(workflow_key:, name: :default, ttl: DEFAULT_TTL)
         @workflow_key = normalize!(workflow_key, label: "workflow_key")
         @name = normalize!(name, label: "name")
         @ttl = ttl
+
+        validate_ttl!(ttl)
       end
 
       def include?(member)
@@ -18,20 +20,11 @@ module R3x
       end
 
       def add(member, ttl: default_ttl)
-        Rails.cache.write(
-          cache_key_for(member),
-          { "added_at" => Time.current.iso8601 },
-          expires_in: ttl
-        )
+        write(member, ttl: ttl)
       end
 
       def add?(member, ttl: default_ttl)
-        Rails.cache.write(
-          cache_key_for(member),
-          { "added_at" => Time.current.iso8601 },
-          expires_in: ttl,
-          unless_exist: true
-        )
+        write(member, ttl: ttl, unless_exist: true)
       end
 
       def delete(member)
@@ -44,6 +37,35 @@ module R3x
 
       def default_ttl
         ttl
+      end
+
+      def write(member, ttl:, unless_exist: false)
+        validate_ttl!(ttl)
+
+        Rails.cache.write(
+          cache_key_for(member),
+          { "added_at" => Time.current.iso8601 },
+          expires_in: ttl,
+          unless_exist: unless_exist
+        )
+      end
+
+      def validate_ttl!(ttl)
+        max_age = solid_cache_max_age
+        return ttl unless max_age && ttl.to_i > max_age
+
+        raise ArgumentError, "ttl can't exceed Solid Cache max_age configured in config/cache.yml"
+      end
+
+      def solid_cache_max_age
+        cache_store = Array(Rails.application.config.cache_store).first
+        return unless cache_store == :solid_cache_store
+
+        cache_config = Rails.application.config_for(:cache).to_h
+        store_options = cache_config[:store_options] || cache_config["store_options"] || {}
+        max_age = store_options[:max_age] || store_options["max_age"]
+
+        max_age.to_i if max_age.present?
       end
 
       def cache_key_for(member)

--- a/lib/r3x/workflow/durable_set.rb
+++ b/lib/r3x/workflow/durable_set.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module R3x
+  module Workflow
+    class DurableSet
+      DEFAULT_TTL = 60.days
+
+      def initialize(workflow_key:, name: :default, ttl: DEFAULT_TTL)
+        @workflow_key = normalize!(workflow_key, label: "workflow_key")
+        @name = normalize!(name, label: "name")
+        @ttl = ttl
+      end
+
+      def include?(member)
+        Rails.cache.exist?(cache_key_for(member))
+      end
+
+      def add(member, ttl: default_ttl)
+        Rails.cache.write(
+          cache_key_for(member),
+          { "added_at" => Time.current.iso8601 },
+          expires_in: ttl
+        )
+      end
+
+      def add?(member, ttl: default_ttl)
+        key = cache_key_for(member)
+        return false if Rails.cache.exist?(key)
+
+        Rails.cache.write(key, { "added_at" => Time.current.iso8601 }, expires_in: ttl)
+        true
+      end
+
+      def delete(member)
+        Rails.cache.delete(cache_key_for(member))
+      end
+
+      private
+
+      attr_reader :workflow_key, :name, :ttl
+
+      def default_ttl
+        ttl
+      end
+
+      def cache_key_for(member)
+        normalized_member = normalize!(member, label: "member")
+        digest = Digest::SHA256.hexdigest(normalized_member)
+
+        [ "r3x", "workflow", workflow_key, "durable_set", name, digest ].join(":")
+      end
+
+      def normalize!(value, label:)
+        normalized = value.to_s.strip
+        return normalized if normalized.present?
+
+        raise ArgumentError, "#{label} can't be blank"
+      end
+    end
+  end
+end

--- a/lib/r3x/workflow/durable_set.rb
+++ b/lib/r3x/workflow/durable_set.rb
@@ -26,11 +26,12 @@ module R3x
       end
 
       def add?(member, ttl: default_ttl)
-        key = cache_key_for(member)
-        return false if Rails.cache.exist?(key)
-
-        Rails.cache.write(key, { "added_at" => Time.current.iso8601 }, expires_in: ttl)
-        true
+        Rails.cache.write(
+          cache_key_for(member),
+          { "added_at" => Time.current.iso8601 },
+          expires_in: ttl,
+          unless_exist: true
+        )
       end
 
       def delete(member)

--- a/test/lib/r3x/client/google/translate_test.rb
+++ b/test/lib/r3x/client/google/translate_test.rb
@@ -1,0 +1,103 @@
+require "test_helper"
+
+module R3x
+  module Client
+    module Google
+      class TranslateTest < ActiveSupport::TestCase
+        test "translate posts to the translation api and returns cleaned text" do
+          delivered = nil
+          captured = {}
+          authorization = FakeAuthorization.new(access_token: "access-token")
+
+          stub_request(:post, "https://translation.googleapis.com/language/translate/v2")
+            .with(headers: { "Authorization" => "Bearer access-token" }) do |req|
+              delivered = MultiJson.load(req.body)
+            end
+            .to_return(
+              status: 200,
+              body: MultiJson.dump(
+                "data" => {
+                  "translations" => [
+                    { "translatedText" => "<p>Hello <strong>world</strong></p>" }
+                  ]
+                }
+              ),
+              headers: { "Content-Type" => "application/json" }
+            )
+
+          with_stubbed_google_credentials(test_credentials) do
+            with_stubbed_google_auth(authorization, captured) do
+              result = Translate.new(credentials_env: "GOOGLE_CREDENTIALS_TEST_APP")
+                .translate(" Ola mundo ", to: "en", from: "pt")
+
+              assert_equal(
+                {
+                  "q" => " Ola mundo ",
+                  "target" => "en",
+                  "source" => "pt",
+                  "format" => "text"
+                },
+                delivered
+              )
+              assert_equal "https://www.googleapis.com/auth/cloud-translation", captured[:scope]
+              assert_equal "<p>Hello <strong>world</strong></p>", result
+            end
+          end
+        end
+
+        private
+
+        def test_credentials
+          {
+            "client_id" => "client-id",
+            "client_secret" => "client-secret",
+            "refresh_token" => "refresh-token"
+          }
+        end
+
+        def with_stubbed_google_credentials(result)
+          singleton_class = R3x::Client::Google::Credentials.singleton_class
+          original_method = R3x::Client::Google::Credentials.method(:from_env)
+
+          singleton_class.define_method(:from_env) do |_credentials_env|
+            result
+          end
+
+          yield
+        ensure
+          singleton_class.define_method(:from_env, original_method)
+        end
+
+        def with_stubbed_google_auth(result, captured)
+          singleton_class = R3x::Client::GoogleAuth.singleton_class
+          original_method = R3x::Client::GoogleAuth.method(:from_json)
+
+          singleton_class.define_method(:from_json) do |_parsed_json, scope:|
+            captured[:scope] = scope
+            result
+          end
+
+          yield
+        ensure
+          singleton_class.define_method(:from_json, original_method)
+        end
+
+        class FakeAuthorization
+          attr_reader :access_token
+
+          def initialize(access_token:)
+            @access_token = access_token
+          end
+
+          def expires_within?(_seconds)
+            false
+          end
+
+          def fetch_access_token!
+            access_token
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/lib/r3x/workflow/context_test.rb
+++ b/test/lib/r3x/workflow/context_test.rb
@@ -93,6 +93,15 @@ module R3x
         assert_instance_of R3x::Client::Google::Gmail, gmail
       end
 
+      test "client proxy builds google translate client from credentials env" do
+        trigger = R3x::Triggers::Schedule.new(cron: "0 13 * * *")
+        trigger_execution = R3x::TriggerManager::Execution.new(trigger: trigger, workflow_key: "test")
+        ctx = Context.new(trigger: trigger_execution, workflow_key: "test")
+        translate = ctx.client.google_translate(credentials_env: "GOOGLE_CREDENTIALS_MISSING")
+
+        assert_instance_of R3x::Client::Google::Translate, translate
+      end
+
       test "client proxy builds discord webhook client" do
         with_env("DISCORD_WEBHOOK_URL_TEST" => "https://discord.test/webhook") do
           ctx = Context.new(

--- a/test/lib/r3x/workflow_test.rb
+++ b/test/lib/r3x/workflow_test.rb
@@ -765,6 +765,48 @@ module R3x
       end
     end
 
+    test "ctx durable_set add? uses atomic cache writes" do
+      context = R3x::Workflow::Context.new(
+        trigger: R3x::TriggerManager::Execution.new(
+          trigger: R3x::Triggers::Manual.new,
+          workflow_key: "atomic_add_predicate_workflow",
+          payload: nil
+        ),
+        workflow_key: "atomic_add_predicate_workflow"
+      )
+      cache = Class.new do
+        attr_reader :writes
+
+        def initialize
+          @writes = []
+          @written = false
+        end
+
+        def exist?(_key)
+          raise "add? must not check existence separately"
+        end
+
+        def write(key, value, expires_in:, unless_exist: false)
+          writes << { key: key, value: value, expires_in: expires_in, unless_exist: unless_exist }
+          return false if unless_exist && @written
+
+          @written = true
+        end
+      end.new
+      original_cache = Rails.cache
+
+      Rails.cache = cache
+      begin
+        durable_set = context.durable_set
+
+        assert durable_set.add?("item-1")
+        refute durable_set.add?("item-1")
+        assert_equal [ true, true ], cache.writes.map { |write| write[:unless_exist] }
+      ensure
+        Rails.cache = original_cache
+      end
+    end
+
     test "ctx durable_set deletes members" do
       context = R3x::Workflow::Context.new(
         trigger: R3x::TriggerManager::Execution.new(

--- a/test/lib/r3x/workflow_test.rb
+++ b/test/lib/r3x/workflow_test.rb
@@ -662,5 +662,134 @@ module R3x
       ENV["R3X_SKIP_CACHE"] = original_skip_cache
       Rails.define_singleton_method(:env, original_env)
     end
+
+    test "ctx durable_set stores membership across calls" do
+      context = R3x::Workflow::Context.new(
+        trigger: R3x::TriggerManager::Execution.new(
+          trigger: R3x::Triggers::Manual.new,
+          workflow_key: "durable_set_workflow",
+          payload: nil
+        ),
+        workflow_key: "durable_set_workflow"
+      )
+      cache = ActiveSupport::Cache::MemoryStore.new
+      original_cache = Rails.cache
+
+      Rails.cache = cache
+      begin
+        durable_set = context.durable_set
+
+        refute durable_set.include?("item-1")
+        durable_set.add("item-1")
+        assert durable_set.include?("item-1")
+      ensure
+        Rails.cache = original_cache
+      end
+    end
+
+    test "ctx durable_set scopes keys by set name" do
+      context = R3x::Workflow::Context.new(
+        trigger: R3x::TriggerManager::Execution.new(
+          trigger: R3x::Triggers::Manual.new,
+          workflow_key: "named_durable_set_workflow",
+          payload: nil
+        ),
+        workflow_key: "named_durable_set_workflow"
+      )
+      cache = ActiveSupport::Cache::MemoryStore.new
+      original_cache = Rails.cache
+
+      Rails.cache = cache
+      begin
+        default_set = context.durable_set
+        sent_set = context.durable_set(:sent)
+
+        default_set.add("item-1")
+
+        assert default_set.include?("item-1")
+        refute sent_set.include?("item-1")
+      ensure
+        Rails.cache = original_cache
+      end
+    end
+
+    test "ctx durable_set scopes keys by workflow" do
+      trigger = R3x::Triggers::Manual.new
+      first_context = R3x::Workflow::Context.new(
+        trigger: R3x::TriggerManager::Execution.new(trigger: trigger, workflow_key: "workflow_one", payload: nil),
+        workflow_key: "workflow_one"
+      )
+      second_context = R3x::Workflow::Context.new(
+        trigger: R3x::TriggerManager::Execution.new(trigger: trigger, workflow_key: "workflow_two", payload: nil),
+        workflow_key: "workflow_two"
+      )
+      cache = ActiveSupport::Cache::MemoryStore.new
+      original_cache = Rails.cache
+
+      Rails.cache = cache
+      begin
+        first_context.durable_set.add("item-1")
+
+        assert first_context.durable_set.include?("item-1")
+        refute second_context.durable_set.include?("item-1")
+      ensure
+        Rails.cache = original_cache
+      end
+    end
+
+    test "ctx durable_set add? returns true for new members and false for existing" do
+      context = R3x::Workflow::Context.new(
+        trigger: R3x::TriggerManager::Execution.new(
+          trigger: R3x::Triggers::Manual.new,
+          workflow_key: "add_predicate_workflow",
+          payload: nil
+        ),
+        workflow_key: "add_predicate_workflow"
+      )
+      cache = ActiveSupport::Cache::MemoryStore.new
+      original_cache = Rails.cache
+
+      Rails.cache = cache
+      begin
+        durable_set = context.durable_set
+
+        assert durable_set.add?("item-1")
+        refute durable_set.add?("item-1")
+        assert durable_set.include?("item-1")
+
+        assert durable_set.add?("item-2")
+        refute durable_set.add?("item-2")
+        assert durable_set.include?("item-2")
+      ensure
+        Rails.cache = original_cache
+      end
+    end
+
+    test "ctx durable_set deletes members" do
+      context = R3x::Workflow::Context.new(
+        trigger: R3x::TriggerManager::Execution.new(
+          trigger: R3x::Triggers::Manual.new,
+          workflow_key: "delete_durable_set_workflow",
+          payload: nil
+        ),
+        workflow_key: "delete_durable_set_workflow"
+      )
+      cache = ActiveSupport::Cache::MemoryStore.new
+      original_cache = Rails.cache
+
+      Rails.cache = cache
+      begin
+        durable_set = context.durable_set
+        durable_set.add("item-1")
+
+        assert durable_set.include?("item-1")
+
+        durable_set.delete("item-1")
+
+        refute durable_set.include?("item-1")
+      ensure
+        Rails.cache = original_cache
+      end
+    end
   end
 end

--- a/test/lib/r3x/workflow_test.rb
+++ b/test/lib/r3x/workflow_test.rb
@@ -737,6 +737,99 @@ module R3x
       end
     end
 
+    test "ctx durable_set uses ninety day default ttl" do
+      context = R3x::Workflow::Context.new(
+        trigger: R3x::TriggerManager::Execution.new(
+          trigger: R3x::Triggers::Manual.new,
+          workflow_key: "default_ttl_workflow",
+          payload: nil
+        ),
+        workflow_key: "default_ttl_workflow"
+      )
+      cache = Class.new do
+        attr_reader :writes
+
+        def initialize
+          @writes = []
+        end
+
+        def write(key, value, expires_in:, unless_exist: false)
+          writes << { key: key, value: value, expires_in: expires_in, unless_exist: unless_exist }
+          true
+        end
+      end.new
+      original_cache = Rails.cache
+
+      Rails.cache = cache
+      begin
+        context.durable_set.add("item-1")
+
+        assert_equal 90.days, cache.writes.last[:expires_in]
+      ensure
+        Rails.cache = original_cache
+      end
+    end
+
+    test "ctx durable_set rejects ttl above configured Solid Cache max_age" do
+      context = R3x::Workflow::Context.new(
+        trigger: R3x::TriggerManager::Execution.new(
+          trigger: R3x::Triggers::Manual.new,
+          workflow_key: "ttl_validation_workflow",
+          payload: nil
+        ),
+        workflow_key: "ttl_validation_workflow"
+      )
+      original_cache_store = Rails.application.config.method(:cache_store)
+      original_config_for = Rails.application.method(:config_for)
+
+      Rails.application.config.define_singleton_method(:cache_store) { :solid_cache_store }
+      Rails.application.define_singleton_method(:config_for) do |name|
+        return { store_options: { max_age: 90.days.to_i } } if name == :cache
+
+        original_config_for.call(name)
+      end
+
+      error = assert_raises(ArgumentError) do
+        context.durable_set(ttl: 91.days)
+      end
+
+      assert_equal "ttl can't exceed Solid Cache max_age configured in config/cache.yml", error.message
+    ensure
+      Rails.application.config.define_singleton_method(:cache_store, original_cache_store)
+      Rails.application.define_singleton_method(:config_for, original_config_for)
+    end
+
+    test "ctx durable_set rejects per-call ttl above configured Solid Cache max_age" do
+      context = R3x::Workflow::Context.new(
+        trigger: R3x::TriggerManager::Execution.new(
+          trigger: R3x::Triggers::Manual.new,
+          workflow_key: "per_call_ttl_validation_workflow",
+          payload: nil
+        ),
+        workflow_key: "per_call_ttl_validation_workflow"
+      )
+      original_cache_store = Rails.application.config.method(:cache_store)
+      original_config_for = Rails.application.method(:config_for)
+
+      Rails.application.config.define_singleton_method(:cache_store) { :solid_cache_store }
+      Rails.application.define_singleton_method(:config_for) do |name|
+        return { store_options: { max_age: 90.days.to_i } } if name == :cache
+
+        original_config_for.call(name)
+      end
+
+      durable_set = context.durable_set
+
+      error = assert_raises(ArgumentError) do
+        durable_set.add("item-1", ttl: 91.days)
+      end
+
+      assert_equal "ttl can't exceed Solid Cache max_age configured in config/cache.yml", error.message
+    ensure
+      Rails.application.config.define_singleton_method(:cache_store, original_cache_store)
+      Rails.application.define_singleton_method(:config_for, original_config_for)
+    end
+
     test "ctx durable_set add? returns true for new members and false for existing" do
       context = R3x::Workflow::Context.new(
         trigger: R3x::TriggerManager::Execution.new(


### PR DESCRIPTION
- Implement R3x::Workflow::DurableSet backed by Rails.cache.
- Expose ctx.durable_set(name = :default, ttl: 60.days) on Context.
- Add workflow_key to Context and scope set keys by workflow.
- Add tests for include?, add, add?, delete and scoping behavior.
- Update docs and AGENTS.md to document durable_set usage.