### PR TITLE
Introduce GemLoader; lazy-load heavy gems

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,11 +13,6 @@
 # Optional: example override if you want a different app/env-specific secret.
 # R3X_VAULT_SECRET_PATH=secret/data/env/r3x-staging
 
-# LLM Configuration
-# Optional: Set to "true" to refresh LLM models from providers at startup.
-# This fetches the latest model list from configured providers (e.g., Gemini).
-# R3X_LLM_REFRESH_MODELS=true
-
 # Prometheus Configuration
 # Optional: URL of your Prometheus server for metrics scraping.
 # PROMETHEUS_URL=http://localhost:9090

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,9 @@ This Rails app uses a small set of preferred libraries for common integration wo
 - `lib/r3x/trigger_manager.rb` + `lib/r3x/trigger_manager/`: trigger infrastructure — `R3x::TriggerManager::Collection` (manages workflow triggers as a hash keyed by `unique_key`) and `R3x::TriggerManager::Execution` (wraps a trigger for runtime use).
 - `app/lib/r3x/`: runtime support code such as client wrappers and shared concerns.
 - `app/lib/r3x/client/google/credentials.rb`: shared Google credentials loader used by Gmail and Google Sheets integrations.
+- `lib/r3x/gem_loader.rb`: tiny helper for one-time lazy `require` of heavy optional gems used by integrations and workflow helpers.
 - `app/lib/r3x/client/google/gmail.rb`: Gmail API client used by workflows via `ctx.client.gmail(...)`.
+- `lib/r3x/workflow/llm_schema.rb`: lazy wrapper around `RubyLLM::Schema` for workflows that need structured LLM output.
 - `R3x::Client::Google` is a project namespace; when referencing the third-party Google gem namespace, use `::Google` to avoid constant collisions.
 - `app/jobs/r3x/`: job entrypoints, especially `R3x::RunWorkflowJob`, which resolves a workflow key and dispatches to the workflow job class, and `R3x::ChangeDetectionJob`, which evaluates change-detecting triggers before enqueueing workflow runs.
 - `app/models/r3x/`: runtime support models such as `R3x::TriggerState` for per-trigger change-detection state.
@@ -35,11 +37,13 @@ This Rails app uses a small set of preferred libraries for common integration wo
 ## Runtime Flow
 
 - Workflows subclass `R3x::Workflow::Base`, declare triggers via the DSL, and implement `#run`.
+- Workflow code can define structured LLM schemas via `R3x::Workflow::LlmSchema.define { ... }`, which lazy-loads `ruby_llm-schema` instead of requiring it for all processes at boot.
 - `R3x::Workflow::Base` is also an `ApplicationJob`; its `#perform` delegates trigger/context setup to `R3x::Workflow::Executor`, stores the context on the job, and then calls `#run` on the current job instance.
 - Workflow-declared DSL objects must validate themselves before being registered; invalid DSL configuration should raise `R3x::ConfigurationError` with collected validation errors.
 - `R3x::Workflow::PackLoader` discovers workflow entrypoints named `workflow.rb` from directories listed in `R3X_WORKFLOW_PATHS`, loads them, and registers their classes in `R3x::Workflow::Registry`.
 - `R3x::RecurringTasksConfig` turns schedulable workflow triggers into Solid Queue dynamic recurring tasks via `SolidQueue::RecurringTask`. All triggers have a `unique_key` (based on type + options hash) used for identification and duplicate detection. `schedule_all!` persists dynamic tasks and sweeps stale ones.
 - Workflow packs are loaded explicitly by process entrypoints, not globally during Rails boot. `bin/rails server` uses a `server do` hook to load workflows and schedule recurring tasks; `bin/jobs` loads workflows before starting the Solid Queue CLI.
+- Production deployments should prefer separate web and jobs controllers/processes over embedding Solid Queue into the Puma web process. If `SOLID_QUEUE_IN_PUMA` is enabled, remember that the Puma plugin can fork an additional Solid Queue supervisor plus worker/dispatcher/scheduler processes inside the same pod.
 - Change-detecting triggers are file-defined trigger objects that provide `cron`, `unique_key`, and `detect_changes(workflow_key:, state:)`. Their durable runtime state lives in `R3x::TriggerState`.
 - `R3x::ChangeDetectionJob` loads the trigger, fetches/updates `R3x::TriggerState`, and only enqueues the workflow job class itself when the trigger reports a change.
 - Because the app currently uses `Solid Queue` as a database-backed backend on the same Active Record database connection, code may intentionally rely on a database transaction covering both `TriggerState` updates and `perform_later`. Do not assume those guarantees survive a future backend or database split.
@@ -63,6 +67,12 @@ Use `bin/workflow` to interact with workflows from the command line. `list` and 
 - When a client is used from app/runtime code, resolve the default through `R3x::Policy.dry_run_for(:key, dry_run)`: development and test should be dry-run by default, production should default to real delivery unless the caller explicitly opts into `dry_run: true`.
 - `R3x::Policy` may also honor per-feature overrides like `R3X_GMAIL_DRY_RUN` and a global `R3X_DRY_RUN` if we need to widen or narrow the policy later.
 - For integration credentials, prefer passing `*_env` references like `credentials_env:` or `api_key_env:` instead of raw secrets or parsed credential hashes. Resolve the secret lazily inside the client/output so dry-run paths can avoid loading credentials when they do not need them.
+- Prefer lazy-loading heavy third-party gems from the client or workflow helper that first needs them. Mark the gem `require: false` in `Gemfile`, then call `R3x::GemLoader.require("...")` at the boundary that actually uses it.
+- Treat lazy-loading as a default design tool for optional workflow integrations and LLM helpers, especially in production boot paths.
+- Reasoning: this app boots the workflow engine for web and jobs processes, but not every workflow uses every integration. Avoid making all processes pay the memory and boot-time cost of Gmail, Google Sheets, Google Calendar, Google Translate, RubyLLM, or similar stacks when only a subset of workflows needs them.
+- When adding or reviewing integration code, actively consider whether the gem should stay eager-loaded or move behind `require: false` plus `R3x::GemLoader.require(...)`. Propose lazy-loading when the dependency is optional, heavy, or only used from specific workflows, CLI commands, or client methods.
+- Prefer putting the lazy-load boundary at the smallest practical edge: the client method, workflow helper, or DSL helper that first needs the dependency. Avoid top-level constants or alias maps that force third-party namespaces to load during Rails eager load if the integration is not universally needed.
+- For workflow-defined structured LLM output, prefer `R3x::Workflow::LlmSchema.define` so workflows that do not declare schemas do not pay to load the schema gem at boot.
 - When integrating a third-party API, put the actual API logic in a dedicated client object under `app/lib/r3x/client/<provider>/...` and keep outputs as thin policy/delivery wrappers.
 - When adding a new output/client with a real delivery path, include a dry-run path first and test that it does not call the external service.
 - Scratchpad scripts should also default to dry-run unless the user explicitly asks for real delivery.

--- a/Gemfile
+++ b/Gemfile
@@ -18,17 +18,17 @@ gem "multi_json"
 gem "nokogiri"
 
 # LLM integration
-gem "ruby_llm"
-gem "ruby_llm-schema"
+gem "ruby_llm", require: false
+gem "ruby_llm-schema", require: false
 
 # Google Translate API
-gem "google-cloud-translate"
+gem "google-cloud-translate", require: false
 
 # Google OAuth and API integration
 gem "googleauth"
-gem "google-apis-calendar_v3"
-gem "google-apis-gmail_v1"
-gem "google-apis-sheets_v4"
+gem "google-apis-calendar_v3", require: false
+gem "google-apis-gmail_v1", require: false
+gem "google-apis-sheets_v4", require: false
 gem "mail"
 
 # Use the database-backed adapters for Rails.cache and Active Job
@@ -36,7 +36,7 @@ gem "solid_cache"
 gem "solid_queue"
 
 # CLI tools
-gem "highline"
+gem "highline", require: false
 
 # Active Job dashboard (requires propshaft for API-only apps)
 gem "mission_control-jobs"
@@ -74,4 +74,4 @@ end
 
 gem "retryable", "~> 3.0"
 
-gem "amazing_print", "~> 2.0"
+gem "amazing_print", "~> 2.0", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem "puma", ">= 5.0"
 
 # HTTP client
 gem "faraday"
+gem "faraday-multipart"
+
+# Json
 gem "multi_json"
 
 # HTML/XML parsing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,6 +518,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   faraday
+  faraday-multipart
   google-apis-calendar_v3
   google-apis-gmail_v1
   google-apis-sheets_v4

--- a/app/lib/r3x/client/google/gmail.rb
+++ b/app/lib/r3x/client/google/gmail.rb
@@ -33,10 +33,12 @@ module R3x
         attr_reader :credentials_env
 
         def build_service
+          R3x::Client::GoogleAuth.require_gmail!
+
           ::Google::Apis::GmailV1::GmailService.new.tap do |service|
             service.authorization = R3x::Client::GoogleAuth.from_json(
               R3x::Client::Google::Credentials.from_env(credentials_env),
-              scope: ::Google::Apis::GmailV1::AUTH_GMAIL_SEND
+              scope: "gmail.send"
             )
           end
         end

--- a/app/lib/r3x/client/google_auth.rb
+++ b/app/lib/r3x/client/google_auth.rb
@@ -3,16 +3,26 @@
 module R3x
   module Client
     module GoogleAuth
-      SCOPE_ALIASES = {
-        "gmail.readonly" => ::Google::Apis::GmailV1::AUTH_GMAIL_READONLY,
-        "gmail.send" => ::Google::Apis::GmailV1::AUTH_GMAIL_SEND,
-        "gmail.compose" => ::Google::Apis::GmailV1::AUTH_GMAIL_COMPOSE,
-        "gmail.modify" => ::Google::Apis::GmailV1::AUTH_GMAIL_MODIFY,
-        "sheets.readonly" => ::Google::Apis::SheetsV4::AUTH_SPREADSHEETS_READONLY,
-        "sheets" => ::Google::Apis::SheetsV4::AUTH_SPREADSHEETS,
-        "calendar.readonly" => ::Google::Apis::CalendarV3::AUTH_CALENDAR_READONLY,
-        "calendar" => ::Google::Apis::CalendarV3::AUTH_CALENDAR
+      GMAIL_SCOPE_ALIASES = {
+        "gmail.readonly" => "AUTH_GMAIL_READONLY",
+        "gmail.send" => "AUTH_GMAIL_SEND",
+        "gmail.compose" => "AUTH_GMAIL_COMPOSE",
+        "gmail.modify" => "AUTH_GMAIL_MODIFY"
       }.freeze
+
+      SHEETS_SCOPE_ALIASES = {
+        "sheets.readonly" => "AUTH_SPREADSHEETS_READONLY",
+        "sheets" => "AUTH_SPREADSHEETS"
+      }.freeze
+
+      CALENDAR_SCOPE_ALIASES = {
+        "calendar.readonly" => "AUTH_CALENDAR_READONLY",
+        "calendar" => "AUTH_CALENDAR"
+      }.freeze
+
+      def self.scope_aliases
+        gmail_scope_aliases.merge(sheets_scope_aliases).merge(calendar_scope_aliases)
+      end
 
       def self.from_json(parsed_json, scope:)
         Signet::OAuth2::Client.new(
@@ -26,7 +36,43 @@ module R3x
 
       def self.resolve_scope(alias_or_scope)
         key = alias_or_scope.to_s
-        SCOPE_ALIASES.fetch(key) { |k| k }
+        case key
+        when *gmail_scope_aliases.keys
+          require_gmail!
+          ::Google::Apis::GmailV1.const_get(gmail_scope_aliases.fetch(key))
+        when *sheets_scope_aliases.keys
+          require_sheets!
+          ::Google::Apis::SheetsV4.const_get(sheets_scope_aliases.fetch(key))
+        when *calendar_scope_aliases.keys
+          require_calendar!
+          ::Google::Apis::CalendarV3.const_get(calendar_scope_aliases.fetch(key))
+        else
+          key
+        end
+      end
+
+      def self.require_gmail!
+        R3x::GemLoader.require("google/apis/gmail_v1")
+      end
+
+      def self.require_sheets!
+        R3x::GemLoader.require("google/apis/sheets_v4")
+      end
+
+      def self.require_calendar!
+        R3x::GemLoader.require("google/apis/calendar_v3")
+      end
+
+      def self.gmail_scope_aliases
+        GMAIL_SCOPE_ALIASES
+      end
+
+      def self.sheets_scope_aliases
+        SHEETS_SCOPE_ALIASES
+      end
+
+      def self.calendar_scope_aliases
+        CALENDAR_SCOPE_ALIASES
       end
     end
   end

--- a/app/lib/r3x/client/google_auth.rb
+++ b/app/lib/r3x/client/google_auth.rb
@@ -30,7 +30,7 @@ module R3x
           client_secret: parsed_json.fetch("client_secret"),
           refresh_token: parsed_json.fetch("refresh_token"),
           token_credential_uri: "https://oauth2.googleapis.com/token",
-          scope: Array(scope)
+          scope: Array(scope).map { |value| resolve_scope(value) }
         ).tap(&:fetch_access_token!)
       end
 

--- a/app/lib/r3x/client/google_sheets.rb
+++ b/app/lib/r3x/client/google_sheets.rb
@@ -28,10 +28,12 @@ module R3x
       attr_reader :spreadsheet_id, :credentials_env, :service
 
       def build_service
+        R3x::Client::GoogleAuth.require_sheets!
+
         service = ::Google::Apis::SheetsV4::SheetsService.new
         service.authorization = R3x::Client::GoogleAuth.from_json(
           R3x::Client::Google::Credentials.from_env(credentials_env),
-          scope: ::Google::Apis::SheetsV4::AUTH_SPREADSHEETS_READONLY
+          scope: "sheets.readonly"
         )
         service
       end

--- a/app/lib/r3x/client/http.rb
+++ b/app/lib/r3x/client/http.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "faraday/multipart"
+
 module R3x
   module Client
     class Http
@@ -37,7 +39,7 @@ module R3x
         file_content_type = content_type || sniff_content_type(file_io)
         rewind_file(file_io)
 
-        file_part = Faraday::Multipart::FilePart.new(file_io, file_content_type, filename)
+        file_part = ::Faraday::Multipart::FilePart.new(file_io, file_content_type, filename)
 
         payload = params.merge(file_field => file_part)
 
@@ -81,9 +83,11 @@ module R3x
       end
 
       def sniff_content_type(file_io)
+        R3x::GemLoader.require("marcel")
+
         position = file_io.pos if file_io.respond_to?(:pos)
 
-        Marcel::MimeType.for(file_io)
+        ::Marcel::MimeType.for(file_io)
       ensure
         restore_file_position(file_io, position)
       end

--- a/app/lib/r3x/client/http.rb
+++ b/app/lib/r3x/client/http.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "faraday/multipart"
-
 module R3x
   module Client
     class Http

--- a/app/lib/r3x/client/llm.rb
+++ b/app/lib/r3x/client/llm.rb
@@ -2,6 +2,8 @@ module R3x
   module Client
     class Llm
       def initialize(api_key:, config_api_key_attr:)
+        R3x::GemLoader.require("ruby_llm")
+
         @llm_context = RubyLLM.context do |config|
           config.public_send(:"#{config_api_key_attr}=", api_key)
         end

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,7 +1,11 @@
 #!/bin/bash -e
 
-# If running the rails server then create or migrate existing database
+# If running the rails server or jobs entrypoint then create or migrate existing database
 if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
+  ./bin/rails db:prepare
+fi
+
+if [[ " $* " == *" ./bin/jobs "* ]]; then
   ./bin/rails db:prepare
 fi
 

--- a/bin/google-oauth
+++ b/bin/google-oauth
@@ -4,7 +4,6 @@
 require_relative "../config/environment"
 require "thor"
 require "signet/oauth_2/client"
-require "highline"
 
 class GoogleOAuthCLI < Thor
   def self.exit_on_failure? = true
@@ -189,7 +188,8 @@ class GoogleOAuthCLI < Thor
   def scopes
     puts ""
     puts "Available scope aliases:"
-    R3x::Client::GoogleAuth::SCOPE_ALIASES.each do |alias_name, scope|
+    R3x::Client::GoogleAuth.scope_aliases.each do |alias_name, const_name|
+      scope = R3x::Client::GoogleAuth.resolve_scope(alias_name)
       puts "  %-24s %s" % [alias_name, scope]
     end
     puts ""
@@ -230,13 +230,15 @@ class GoogleOAuthCLI < Thor
   end
 
   def interactive_scope_selection
+    require "highline"
+
     cli = HighLine.new
 
     puts ""
     puts "=== Select Google API Scopes ==="
     puts ""
 
-    aliases = R3x::Client::GoogleAuth::SCOPE_ALIASES.keys
+    aliases = R3x::Client::GoogleAuth.scope_aliases.keys
     selected_aliases = []
 
     loop do
@@ -250,11 +252,11 @@ class GoogleOAuthCLI < Thor
       puts "Available scopes (selected: #{selected_aliases.size}):"
       puts ""
 
-      choice = cli.choose do |menu|
-        menu.prompt = "Select a scope (or 'done' to finish): "
+        choice = cli.choose do |menu|
+          menu.prompt = "Select a scope (or 'done' to finish): "
 
-        remaining.each do |alias_name|
-          scope = R3x::Client::GoogleAuth::SCOPE_ALIASES[alias_name]
+          remaining.each do |alias_name|
+          scope = R3x::Client::GoogleAuth.resolve_scope(alias_name)
           menu.choice("#{alias_name} (#{scope})") { alias_name }
         end
 

--- a/bin/workflow
+++ b/bin/workflow
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require_relative "../config/environment"
 require "thor"
+require "amazing_print"
 
 logger = ActiveSupport::Logger.new(STDOUT)
 logger.level = Logger::INFO

--- a/config/initializers/r3x_llm_models.rb
+++ b/config/initializers/r3x_llm_models.rb
@@ -1,7 +1,0 @@
-Rails.application.config.after_initialize do
-  if ENV["R3X_LLM_REFRESH_MODELS"] == "true"
-    Rails.logger.info "[R3x::Llm] Refreshing LLM models from providers..."
-    RubyLLM.models.refresh!
-    Rails.logger.info "[R3x::Llm] LLM models refreshed successfully"
-  end
-end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -28,6 +28,8 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
+solid_queue_in_puma = ActiveModel::Type::Boolean.new.cast(ENV["SOLID_QUEUE_IN_PUMA"])
+
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT", 3000)
 
@@ -35,7 +37,7 @@ port ENV.fetch("PORT", 3000)
 plugin :tmp_restart
 
 # Run the Solid Queue supervisor inside of Puma for single-server deployments.
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"] || ENV.fetch("RAILS_ENV", "development") == "development"
+plugin :solid_queue if solid_queue_in_puma || ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -60,13 +60,16 @@ These notes apply to workflow code in general.
 - When a workflow expects structured LLM output, prefer `RubyLLM` schema support.
 - Use a schema when you want JSON-like data back instead of parsing free-form text by hand.
 - Keep the schema close to the prompt so the expected shape is obvious.
-- For nested JSON, define the shape with `array` and `object` blocks on a `RubyLLM::Schema` class,
+- Define new workflow schemas with `R3x::Workflow::LlmSchema.define`.
+- This is the current convention because it keeps `ruby_llm-schema` off the boot path for workflows that do not use structured LLM output.
+- Older direct inheritance from `RubyLLM::Schema` still works, but treat it as legacy in new code.
+- For nested JSON, define the shape with `array` and `object` blocks inside the helper block,
   then pass that schema to `message(...)`.
 - Read the parsed structured result from `response.content`; avoid manual JSON parsing when the
   schema already captures the shape.
 
   ```ruby
-  class WeeklyDigestSchema < RubyLLM::Schema
+  WeeklyDigestSchema = R3x::Workflow::LlmSchema.define do
     array :EN do
       object :entry do
         string :name

--- a/lib/r3x/gem_loader.rb
+++ b/lib/r3x/gem_loader.rb
@@ -1,0 +1,19 @@
+module R3x
+  module GemLoader
+    extend self
+
+    MUTEX = Mutex.new
+    LOADED_FEATURES = Concurrent::Map.new
+
+    def require(feature)
+      return false if LOADED_FEATURES[feature]
+
+      MUTEX.synchronize do
+        return false if LOADED_FEATURES[feature]
+
+        Kernel.require(feature)
+        LOADED_FEATURES[feature] = true
+      end
+    end
+  end
+end

--- a/lib/r3x/workflow/base.rb
+++ b/lib/r3x/workflow/base.rb
@@ -39,7 +39,7 @@ module R3x
         end
 
         if Rails.env.production?
-          raise RuntimeError, "with_cache is disabled in production"
+          raise RuntimeError, "with_cache is disabled in production, if you need to use it, please set R3X_SKIP_CACHE=true in the environment variables"
         end
 
         Rails.cache.fetch(cache_key_for(block), force: force, expires_in: CACHE_TTL, race_condition_ttl: 5.minutes) do

--- a/lib/r3x/workflow/llm_schema.rb
+++ b/lib/r3x/workflow/llm_schema.rb
@@ -1,0 +1,13 @@
+module R3x
+  module Workflow
+    module LlmSchema
+      extend self
+
+      def define(&block)
+        R3x::GemLoader.require("ruby_llm/schema")
+
+        Class.new(RubyLLM::Schema, &block)
+      end
+    end
+  end
+end

--- a/test/lib/r3x/client/google/gmail_test.rb
+++ b/test/lib/r3x/client/google/gmail_test.rb
@@ -95,6 +95,8 @@ module R3x
         end
 
         def with_stubbed_gmail_service(result)
+          R3x::Client::GoogleAuth.require_gmail!
+
           singleton_class = ::Google::Apis::GmailV1::GmailService.singleton_class
           original_method = ::Google::Apis::GmailV1::GmailService.method(:new)
 

--- a/test/lib/r3x/client/google_auth_test.rb
+++ b/test/lib/r3x/client/google_auth_test.rb
@@ -9,6 +9,32 @@ module R3x
         assert_equal ::Google::Apis::GmailV1::AUTH_GMAIL_SEND, scope
       end
 
+      test "from_json resolves scope aliases before fetching token" do
+        stub_client = Object.new
+        captured_scope = nil
+
+        stub_client.define_singleton_method(:fetch_access_token!) { true }
+
+        original_new = Signet::OAuth2::Client.method(:new)
+        Signet::OAuth2::Client.singleton_class.define_method(:new) do |**kwargs|
+          captured_scope = kwargs.fetch(:scope)
+          stub_client
+        end
+
+        GoogleAuth.from_json(
+          {
+            "client_id" => "client-id",
+            "client_secret" => "client-secret",
+            "refresh_token" => "refresh-token"
+          },
+          scope: "gmail.send"
+        )
+
+        assert_equal [ ::Google::Apis::GmailV1::AUTH_GMAIL_SEND ], captured_scope
+      ensure
+        Signet::OAuth2::Client.singleton_class.define_method(:new, original_new)
+      end
+
       test "resolve_scope returns raw value for unknown aliases" do
         assert_equal "https://example.test/scope", GoogleAuth.resolve_scope("https://example.test/scope")
       end

--- a/test/lib/r3x/client/google_auth_test.rb
+++ b/test/lib/r3x/client/google_auth_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+module R3x
+  module Client
+    class GoogleAuthTest < ActiveSupport::TestCase
+      test "resolve_scope loads gmail constants lazily" do
+        scope = GoogleAuth.resolve_scope("gmail.send")
+
+        assert_equal ::Google::Apis::GmailV1::AUTH_GMAIL_SEND, scope
+      end
+
+      test "resolve_scope returns raw value for unknown aliases" do
+        assert_equal "https://example.test/scope", GoogleAuth.resolve_scope("https://example.test/scope")
+      end
+    end
+  end
+end

--- a/test/lib/r3x/workflow/llm_schema_test.rb
+++ b/test/lib/r3x/workflow/llm_schema_test.rb
@@ -9,7 +9,7 @@ module R3x
         end
 
         assert klass < RubyLLM::Schema
-        assert_equal [:status], klass.properties.keys
+        assert_equal [ :status ], klass.properties.keys
       end
     end
   end

--- a/test/lib/r3x/workflow/llm_schema_test.rb
+++ b/test/lib/r3x/workflow/llm_schema_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+module R3x
+  module Workflow
+    class LlmSchemaTest < ActiveSupport::TestCase
+      test "define loads ruby_llm schema lazily and returns a schema class" do
+        klass = LlmSchema.define do
+          string :status
+        end
+
+        assert klass < RubyLLM::Schema
+        assert_equal [:status], klass.properties.keys
+      end
+    end
+  end
+end

--- a/test/lib/r3x/workflow_test.rb
+++ b/test/lib/r3x/workflow_test.rb
@@ -411,7 +411,7 @@ module R3x
         workflow.with_cache { "cached" }
       end
 
-      assert_equal "with_cache is disabled in production", error.message
+      assert_equal "with_cache is disabled in production, if you need to use it, please set R3X_SKIP_CACHE=true in the environment variables", error.message
     ensure
       Rails.define_singleton_method(:env, original_env)
     end


### PR DESCRIPTION
- Add lib/r3x/gem_loader to safely require optional gems once
- Mark ruby_llm, google APIs and other heavy gems require: false
- Update R3x::Client::GoogleAuth to resolve and require scopes lazily
- Make Gmail/Sheets/LLM clients call GemLoader before using APIs
- Add R3x::Workflow::LlmSchema.define to lazily build schemas
- Update docs and AGENTS.md to document the lazy-loading policy
- Add tests for GoogleAuth scope resolution and LlmSchema loading
- Also prepare DB for bin/jobs, cast puma env to boolean, tweak CLIs