### PR TITLE
Support Google Translate scope alias

### DIFF
--- a/app/lib/r3x/client/google/translate.rb
+++ b/app/lib/r3x/client/google/translate.rb
@@ -5,7 +5,6 @@ module R3x
     module Google
       class Translate
         API_URL = "https://translation.googleapis.com/language/translate/v2"
-        OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-translation"
 
         def initialize(credentials_env:)
           @credentials_env = credentials_env
@@ -28,7 +27,7 @@ module R3x
         def authorization
           @authorization ||= R3x::Client::GoogleAuth.from_json(
             R3x::Client::Google::Credentials.from_env(credentials_env),
-            scope: OAUTH_SCOPE
+            scope: R3x::Client::GoogleAuth.resolve_scope("translate")
           )
         end
 

--- a/app/lib/r3x/client/google_auth.rb
+++ b/app/lib/r3x/client/google_auth.rb
@@ -20,8 +20,15 @@ module R3x
         "calendar" => "AUTH_CALENDAR"
       }.freeze
 
+      TRANSLATE_SCOPE_ALIASES = {
+        "translate" => "https://www.googleapis.com/auth/cloud-translation"
+      }.freeze
+
       def self.scope_aliases
-        gmail_scope_aliases.merge(sheets_scope_aliases).merge(calendar_scope_aliases)
+        gmail_scope_aliases
+          .merge(sheets_scope_aliases)
+          .merge(calendar_scope_aliases)
+          .merge(translate_scope_aliases)
       end
 
       def self.from_json(parsed_json, scope:)
@@ -46,6 +53,8 @@ module R3x
         when *calendar_scope_aliases.keys
           require_calendar!
           ::Google::Apis::CalendarV3.const_get(calendar_scope_aliases.fetch(key))
+        when *translate_scope_aliases.keys
+          translate_scope_aliases.fetch(key)
         else
           key
         end
@@ -73,6 +82,10 @@ module R3x
 
       def self.calendar_scope_aliases
         CALENDAR_SCOPE_ALIASES
+      end
+
+      def self.translate_scope_aliases
+        TRANSLATE_SCOPE_ALIASES
       end
     end
   end

--- a/test/lib/r3x/client/google_auth_test.rb
+++ b/test/lib/r3x/client/google_auth_test.rb
@@ -35,6 +35,12 @@ module R3x
         Signet::OAuth2::Client.singleton_class.define_method(:new, original_new)
       end
 
+      test "resolve_scope resolves translate alias directly" do
+        scope = GoogleAuth.resolve_scope("translate")
+
+        assert_equal "https://www.googleapis.com/auth/cloud-translation", scope
+      end
+
       test "resolve_scope returns raw value for unknown aliases" do
         assert_equal "https://example.test/scope", GoogleAuth.resolve_scope("https://example.test/scope")
       end


### PR DESCRIPTION
- Add TRANSLATE_SCOPE_ALIASES and translate_scope_aliases in GoogleAuth
- Merge translate aliases into scope_aliases so they are resolvable
- Make Translate client call GoogleAuth.resolve_scope("translate")
- Remove hard-coded OAUTH_SCOPE constant from Translate client
- Add test asserting "translate" resolves to cloud-translation URL