### PR TITLE
Refactor RuntimeProfile and consolidate headless checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,7 +287,7 @@ This repo uses `.githooks/` directory for git hooks. The pre-commit hook runs `b
 - **Good**: `triggers.select(&:cron_schedulable?)`
 - **Bad**: `triggers.select { |t| t.type == :schedule }`
 - Prefer instance variables only for state the object needs across method calls or as part of its long-lived identity.
-- Do not keep one-time derived configuration in instance variables when it is only used during initialization or validation; keep it local or behind a small helper method instead.
+- Do not use instance variables as local variables inside a single method. If a derived value is only needed within one method, use a local variable or extract a small helper. Instance variables are appropriate for memoization when a helper is called from multiple places and the result is stable for the lifetime of the object.
 - When multiple classes share a capability, extract a small concern or module with an explicit predicate and required methods.
 - **Good**: `include R3x::Triggers::Concerns::CronSchedulable`
 - Framework code should avoid hardcoding knowledge of concrete subtypes. Prefer polymorphism, capability predicates, and object-owned methods like `to_h`.
@@ -347,6 +347,32 @@ response.content
 - When intermediate results are used multiple times
 - When the intermediate value has semantic meaning that aids comprehension
 - When debugging requires inspecting intermediate state
+
+### Module-Level Singleton API
+
+When a module exists solely as a namespace for a group of related class-level (singleton) methods, use `extend self`. This avoids repeating `self.` on every method definition and signals that the module is intended to be called directly as `ModuleName.method`.
+
+**Good:**
+```ruby
+module R3x::RuntimeProfile
+  extend self
+
+  def current
+    # ...
+  end
+end
+```
+
+**Bad:**
+```ruby
+module R3x::RuntimeProfile
+  def self.current
+    # ...
+  end
+end
+```
+
+Do **not** use `extend self` in modules that are meant to be mixed in (`include`) or that contain both instance and class methods. Reserve it for pure singleton-method namespaces.
 
 ## Design Principles
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,8 +31,8 @@ module R3x
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.1
 
-    # Please, add to the `ignore` list any other `lib` subdirectories that do
-    # not contain `.rb` files, or that should not be reloaded or eager loaded.
+    # Please, add to the `ignore` list any other `lib` subdirectories that
+    # do not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
     config.autoload_paths << Rails.root.join("app/lib")
@@ -65,6 +65,10 @@ module R3x
         require "action_controller"
         ActionController::Base.include_all_helpers = false
       end
+    else
+      config.api_only = true
+      config.mission_control.jobs.base_controller_class = "R3x::WebController"
+      server { R3x::Workflow::Entrypoint.boot_server!(rails_env: Rails.env) }
     end
 
     # Configuration for the application, engines, and railties goes here.
@@ -79,11 +83,5 @@ module R3x
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.log_formatter = R3x::LogFormatter.new
-
-    unless R3x::RuntimeProfile.headless?
-      config.api_only = true
-      config.mission_control.jobs.base_controller_class = "R3x::WebController"
-      server { R3x::Workflow::Entrypoint.boot_server!(rails_env: Rails.env) }
-    end
   end
 end

--- a/config/runtime_profile.rb
+++ b/config/runtime_profile.rb
@@ -6,32 +6,34 @@ module R3x
     HEADLESS_PROFILES = %w[jobs workflow_cli].freeze
     SUPPORTED_PROFILES = [ DEFAULT_PROFILE, *HEADLESS_PROFILES ].freeze
 
-    def current(env = ENV)
-      profile = env.fetch("R3X_RUNTIME_PROFILE", "").to_s
-      profile = DEFAULT_PROFILE if profile.empty?
+    def current
+      @current ||= begin
+        profile = ENV.fetch("R3X_RUNTIME_PROFILE", "").to_s
+        profile = DEFAULT_PROFILE if profile.empty?
 
-      case profile
-      when *SUPPORTED_PROFILES
-        profile
-      else
-        raise ArgumentError, "Unsupported R3X_RUNTIME_PROFILE: #{profile}"
+        case profile
+        when *SUPPORTED_PROFILES
+          profile
+        else
+          raise ArgumentError, "Unsupported R3X_RUNTIME_PROFILE: #{profile}"
+        end
       end
     end
 
-    def jobs?(env = ENV)
-      current(env) == "jobs"
+    def jobs?
+      current == "jobs"
     end
 
-    def workflow_cli?(env = ENV)
-      current(env) == "workflow_cli"
+    def workflow_cli?
+      current == "workflow_cli"
     end
 
-    def headless?(env = ENV)
-      HEADLESS_PROFILES.include?(current(env))
+    def headless?
+      HEADLESS_PROFILES.include?(current)
     end
 
-    def bundler_groups(env = ENV)
-      headless?(env) ? [] : [ :web ]
+    def bundler_groups
+      headless? ? [] : [ :web ]
     end
   end
 end

--- a/test/lib/r3x/runtime_profile_test.rb
+++ b/test/lib/r3x/runtime_profile_test.rb
@@ -2,37 +2,54 @@ require "test_helper"
 
 module R3x
   class RuntimeProfileTest < ActiveSupport::TestCase
+    setup do
+      @original_runtime_profile = ENV.delete("R3X_RUNTIME_PROFILE")
+      RuntimeProfile.instance_variable_set(:@current, nil)
+    end
+
+    teardown do
+      RuntimeProfile.instance_variable_set(:@current, nil)
+
+      if @original_runtime_profile
+        ENV["R3X_RUNTIME_PROFILE"] = @original_runtime_profile
+      else
+        ENV.delete("R3X_RUNTIME_PROFILE")
+      end
+    end
+
     test "defaults to web profile" do
-      assert_equal "web", RuntimeProfile.current({})
-      assert_equal [ :web ], RuntimeProfile.bundler_groups({})
-      refute RuntimeProfile.jobs?({})
-      refute RuntimeProfile.workflow_cli?({})
-      refute RuntimeProfile.headless?({})
+      assert_equal "web", RuntimeProfile.current
+      assert_equal [ :web ], RuntimeProfile.bundler_groups
+      refute RuntimeProfile.jobs?
+      refute RuntimeProfile.workflow_cli?
+      refute RuntimeProfile.headless?
     end
 
     test "recognizes jobs profile" do
-      env = { "R3X_RUNTIME_PROFILE" => "jobs" }
+      ENV["R3X_RUNTIME_PROFILE"] = "jobs"
 
-      assert_equal "jobs", RuntimeProfile.current(env)
-      assert_equal [], RuntimeProfile.bundler_groups(env)
-      assert RuntimeProfile.jobs?(env)
-      refute RuntimeProfile.workflow_cli?(env)
-      assert RuntimeProfile.headless?(env)
+      assert_equal "jobs", RuntimeProfile.current
+      assert_equal [], RuntimeProfile.bundler_groups
+      assert RuntimeProfile.jobs?
+      refute RuntimeProfile.workflow_cli?
+      assert RuntimeProfile.headless?
     end
 
     test "recognizes workflow_cli profile" do
-      env = { "R3X_RUNTIME_PROFILE" => "workflow_cli" }
+      ENV["R3X_RUNTIME_PROFILE"] = "workflow_cli"
 
-      assert_equal "workflow_cli", RuntimeProfile.current(env)
-      assert_equal [], RuntimeProfile.bundler_groups(env)
-      refute RuntimeProfile.jobs?(env)
-      assert RuntimeProfile.workflow_cli?(env)
-      assert RuntimeProfile.headless?(env)
+      assert_equal "workflow_cli", RuntimeProfile.current
+      assert_equal [], RuntimeProfile.bundler_groups
+      refute RuntimeProfile.jobs?
+      assert RuntimeProfile.workflow_cli?
+      assert RuntimeProfile.headless?
     end
 
     test "rejects unsupported profiles" do
+      ENV["R3X_RUNTIME_PROFILE"] = "sidekiq"
+
       error = assert_raises(ArgumentError) do
-        RuntimeProfile.current({ "R3X_RUNTIME_PROFILE" => "sidekiq" })
+        RuntimeProfile.current
       end
 
       assert_includes error.message, "Unsupported R3X_RUNTIME_PROFILE"


### PR DESCRIPTION
## Summary

- Remove injectable `env` parameter from `R3x::RuntimeProfile`; read `ENV` directly.
- Group scattered `headless?` checks in `config/application.rb` into a single `if/else` block.
- Add memoization to `RuntimeProfile.current` (stable for process lifetime).
- Update tests to manipulate real `ENV` with teardown restore.
- Add `Module-Level Singleton API` convention to `AGENTS.md`.
- Clarify instance-variable guidance in `AGENTS.md`: ivars are fine for memoizing multi-call helpers, but not as local-variable replacements inside a single method.

## Checklist

- [x] `bin/ci` passes locally
- [x] AGENTS.md references linted
