### PR TITLE
feat(dashboard): polish run table layout and timestamp UX

### DIFF
--- a/app/helpers/r3x/dashboard/application_helper.rb
+++ b/app/helpers/r3x/dashboard/application_helper.rb
@@ -42,12 +42,17 @@ module R3x
 
         displayed_time = dashboard_display_time(time)
 
-        time_tag(
-          displayed_time,
-          dashboard_relative_time(time),
+        content_tag(
+          :time,
           datetime: displayed_time.iso8601,
+          class: "timestamp-hoverable",
           title: displayed_time.strftime("%Y-%m-%d %H:%M:%S %Z")
-        )
+        ) do
+          safe_join([
+            content_tag(:span, dashboard_relative_time(time), class: "timestamp-relative"),
+            content_tag(:span, displayed_time.strftime("%Y-%m-%d %H:%M:%S %Z"), class: "timestamp-absolute")
+          ])
+        end
       end
 
       def dashboard_absolute_timestamp(time)

--- a/app/lib/r3x/dashboard/workflow/runs.rb
+++ b/app/lib/r3x/dashboard/workflow/runs.rb
@@ -53,6 +53,7 @@ module R3x
               queue_name: job.queue_name,
               recorded_at: job.recorded_at,
               scheduled_at: job.scheduled_execution&.scheduled_at || job.scheduled_at,
+              started_at: job.claimed_execution&.created_at,
               status: job.status,
               trigger_key: job.trigger_key,
               trigger_payload: job.trigger_payload,

--- a/app/views/layouts/r3x/dashboard.html.erb
+++ b/app/views/layouts/r3x/dashboard.html.erb
@@ -769,6 +769,47 @@
         white-space: nowrap;
       }
 
+      .timestamp-hoverable {
+        cursor: default;
+      }
+
+      .timestamp-hoverable .timestamp-relative {
+        display: inline;
+      }
+
+      .timestamp-hoverable .timestamp-absolute {
+        display: none;
+      }
+
+      .timestamp-hoverable:hover .timestamp-relative {
+        display: none;
+      }
+
+      .timestamp-hoverable:hover .timestamp-absolute {
+        display: inline;
+      }
+
+      .button,
+      button,
+      .chip-link {
+        transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+      }
+
+      .button:hover,
+      button:hover {
+        transform: scale(1.04);
+        box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+      }
+
+      .chip-link:hover {
+        transform: scale(1.04);
+        box-shadow: 0 3px 10px rgba(0, 0, 0, 0.06);
+      }
+
+      .title-link {
+        transition: color 0.15s ease;
+      }
+
       @media (max-width: 960px) {
         .grid.two,
         .stats {

--- a/app/views/r3x/dashboard/workflow_runs/_table.html.erb
+++ b/app/views/r3x/dashboard/workflow_runs/_table.html.erb
@@ -1,4 +1,4 @@
-<% columns = local_assigns.fetch(:columns, %i[workflow result observed trigger run_id open]) %>
+<% columns = local_assigns.fetch(:columns, %i[workflow result observed trigger open]) %>
 
 <div class="table-wrap">
   <% if runs.empty? %>
@@ -18,9 +18,6 @@
           <% end %>
           <% if columns.include?(:trigger) %>
             <th>Trigger</th>
-          <% end %>
-          <% if columns.include?(:run_id) %>
-            <th>Run ID</th>
           <% end %>
           <% if columns.include?(:open) %>
             <th>Open</th>
@@ -54,10 +51,6 @@
 
             <% if columns.include?(:trigger) %>
               <td><code><%= run[:trigger_key] || "manual/default" %></code></td>
-            <% end %>
-
-            <% if columns.include?(:run_id) %>
-              <td><code><%= run[:job_id] %></code></td>
             <% end %>
 
             <% if columns.include?(:open) %>

--- a/app/views/r3x/dashboard/workflow_runs/index.html.erb
+++ b/app/views/r3x/dashboard/workflow_runs/index.html.erb
@@ -45,6 +45,6 @@
 <section class="panel stack">
   <%= render "r3x/dashboard/workflow_runs/table",
              runs: @runs,
-             columns: %i[workflow result observed trigger run_id open],
+             columns: %i[workflow result observed trigger open],
              empty_message: "No workflow runs match the current filters." %>
 </section>

--- a/app/views/r3x/dashboard/workflow_runs/show.html.erb
+++ b/app/views/r3x/dashboard/workflow_runs/show.html.erb
@@ -42,18 +42,18 @@
 
   <div class="detail-grid">
     <div class="detail-item">
-      <span class="label">Observed</span>
-      <strong><%= dashboard_absolute_timestamp(@run[:recorded_at]) %></strong>
-    </div>
-
-    <div class="detail-item">
-      <span class="label">Trigger</span>
-      <strong><code><%= trigger_key %></code></strong>
+      <span class="label">Started</span>
+      <strong><%= @run[:started_at].present? ? dashboard_absolute_timestamp(@run[:started_at]) : content_tag(:span, "Not started", class: "muted") %></strong>
     </div>
 
     <div class="detail-item">
       <span class="label">Duration</span>
       <strong><%= dashboard_duration(@run[:enqueued_at], terminal_time) %></strong>
+    </div>
+
+    <div class="detail-item">
+      <span class="label">Trigger</span>
+      <strong><code><%= trigger_key %></code></strong>
     </div>
   </div>
 </section>

--- a/app/views/r3x/dashboard/workflows/show.html.erb
+++ b/app/views/r3x/dashboard/workflows/show.html.erb
@@ -45,14 +45,12 @@
 
     <div class="stat">
       <span class="label">Last seen</span>
-      <strong><%= @workflow[:last_seen_at].present? ? dashboard_relative_time(@workflow[:last_seen_at]) : "Never" %></strong>
-      <span class="meta"><%= dashboard_timestamp(@workflow[:last_seen_at]) %></span>
+      <strong><%= @workflow[:last_seen_at].present? ? dashboard_timestamp(@workflow[:last_seen_at]) : "Never" %></strong>
     </div>
 
     <div class="stat">
       <span class="label">Next trigger</span>
-      <strong><%= @workflow[:next_trigger_at].present? ? dashboard_relative_time(@workflow[:next_trigger_at]) : "Manual only" %></strong>
-      <span class="meta"><%= dashboard_timestamp(@workflow[:next_trigger_at]) %></span>
+      <strong><%= @workflow[:next_trigger_at].present? ? dashboard_timestamp(@workflow[:next_trigger_at]) : "Manual only" %></strong>
     </div>
   </div>
 </section>

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -698,11 +698,11 @@ class DashboardTest < ActionDispatch::IntegrationTest
     refute_includes response.body, "<th>Queue</th>"
   end
 
-  test "recent runs table uses run id column instead of queue and inline job label" do
+  test "recent runs table omits queue and inline job label" do
     get "/workflow-runs"
 
     assert_response :success
-    assert_equal [ "Workflow", "Result", "Observed", "Trigger", "Run ID", "Open" ], css_select("table").last.css("thead th").map(&:text)
+    assert_equal [ "Workflow", "Result", "Observed", "Trigger", "Open" ], css_select("table").last.css("thead th").map(&:text)
     refute_includes response.body, "<th>Queue</th>"
     refute_includes response.body, WORKFLOW_JOB_CLASS_NAME
   end


### PR DESCRIPTION
## Summary
Improves dashboard readability by making timestamps reveal absolute time on hover, surfacing run start time, and decluttering the runs table.

## Changes
- Add hoverable timestamp component that swaps relative/absolute time
- Remove Run ID column from runs table to reduce visual noise
- Surface `started_at` on run detail page and reorder fields
- Add subtle hover animations to buttons and chips