### PR TITLE
fix: restrict observed workflow discovery and fallback started_at

### DIFF
--- a/app/lib/r3x/dashboard/workflow/runs.rb
+++ b/app/lib/r3x/dashboard/workflow/runs.rb
@@ -53,7 +53,7 @@ module R3x
               queue_name: job.queue_name,
               recorded_at: job.recorded_at,
               scheduled_at: job.scheduled_execution&.scheduled_at || job.scheduled_at,
-              started_at: job.claimed_execution&.created_at,
+              started_at: job.claimed_execution&.created_at || job.created_at,
               status: job.status,
               trigger_key: job.trigger_key,
               trigger_payload: job.trigger_payload,

--- a/app/models/dashboard/run.rb
+++ b/app/models/dashboard/run.rb
@@ -24,7 +24,7 @@ module Dashboard
       visible_class_names.present? ? where(class_name: visible_class_names) : none
     end
     scope :direct_workflows, -> { excluding_ignored_classes.where("class_name LIKE ?", "Workflows::%") }
-    scope :observed_triggers, -> { excluding_ignored_classes.where("class_name NOT LIKE ?", "Workflows::%") }
+    scope :observed_triggers, -> { excluding_ignored_classes.where(class_name: []) }
     scope :unfinished, -> { where(finished_at: nil).where.missing(:failed_execution) }
     scope :for_status, ->(status) do
       case status.to_s

--- a/app/views/r3x/dashboard/workflow_runs/show.html.erb
+++ b/app/views/r3x/dashboard/workflow_runs/show.html.erb
@@ -43,7 +43,7 @@
   <div class="detail-grid">
     <div class="detail-item">
       <span class="label">Started</span>
-      <strong><%= @run[:started_at].present? ? dashboard_absolute_timestamp(@run[:started_at]) : content_tag(:span, "Not started", class: "muted") %></strong>
+      <strong><%= dashboard_absolute_timestamp(@run[:started_at]) %></strong>
     </div>
 
     <div class="detail-item">

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class DashboardTest < ActionDispatch::IntegrationTest
   include ActiveJob::TestHelper
 
-  WORKFLOW_JOB_CLASS_NAME = R3x::TestSupport::DashboardWorkflowJob.name.freeze
+  WORKFLOW_JOB_CLASS_NAME = DashboardTestWorkflows.ensure_class("TestWorkflow").freeze
 
   setup do
     @original_logs_provider = ENV["R3X_LOGS_PROVIDER"]
@@ -124,7 +124,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
       finished_at = (90 + index).minutes.ago
 
       create_dashboard_workflow(
-        workflow_key: "visible_workflow_#{index}",
+        workflow_key: "visible_workflow#{index}",
         trigger_key: "schedule:visible:#{index}",
         run_status: "finished",
         recorded_at: finished_at
@@ -135,7 +135,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal 10, css_select(".overview-recent-runs-table tbody tr").size
-    assert_includes response.body, "Visible Workflow 0"
+    assert_includes response.body, "Visible Workflow0"
     refute_includes response.body, "CleanupJob"
   end
 
@@ -827,7 +827,7 @@ class DashboardTest < ActionDispatch::IntegrationTest
   end
 
   def create_dashboard_workflow(workflow_key:, trigger_key:, run_status: nil, recorded_at: nil, trigger_error_at: nil)
-    job_class_name = ensure_dashboard_job_class("#{workflow_key.camelize}Job").name
+    job_class_name = DashboardTestWorkflows.ensure_class(workflow_key.camelize)
 
     SolidQueue::RecurringTask.create!(
       key: "workflow:#{workflow_key}:#{trigger_key}",
@@ -863,17 +863,5 @@ class DashboardTest < ActionDispatch::IntegrationTest
 
     SolidQueue::FailedExecution.create!(job_id: job.id, error: "#{workflow_key} failed", created_at: recorded_at)
     job
-  end
-
-  def ensure_dashboard_job_class(name)
-    test_jobs = if Object.const_defined?(:TestDashboardJobs, false)
-      Object.const_get(:TestDashboardJobs)
-    else
-      Object.const_set(:TestDashboardJobs, Module.new)
-    end
-
-    return test_jobs.const_get(name, false) if test_jobs.const_defined?(name, false)
-
-    test_jobs.const_set(name, Class.new(R3x::TestSupport::DashboardWorkflowJob))
   end
 end

--- a/test/lib/r3x/dashboard/run_test.rb
+++ b/test/lib/r3x/dashboard/run_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class Dashboard::RunTest < ActiveSupport::TestCase
-  WORKFLOW_JOB_CLASS_NAME = R3x::TestSupport::DashboardWorkflowJob.name.freeze
+  WORKFLOW_JOB_CLASS_NAME = DashboardTestWorkflows.ensure_class("TestWorkflow").freeze
 
   setup do
     TestDbCleanup.clear_runtime_tables!

--- a/test/lib/r3x/dashboard/workflow_catalog_test.rb
+++ b/test/lib/r3x/dashboard/workflow_catalog_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 module R3x
   module Dashboard
     class WorkflowCatalogTest < ActiveSupport::TestCase
-      WORKFLOW_JOB_CLASS_NAME = R3x::TestSupport::DashboardWorkflowJob.name.freeze
+      WORKFLOW_JOB_CLASS_NAME = DashboardTestWorkflows.ensure_class("ScheduledWorkflow").freeze
 
       setup do
         TestDbCleanup.clear_runtime_tables!
@@ -13,9 +13,7 @@ module R3x
         TestDbCleanup.clear_runtime_tables!
       end
 
-      test "collects workflow keys from recurring tasks trigger states and observed direct runs" do
-        observed_job_class_name = ensure_dashboard_job_class("ObservedWorkflowJob").name
-
+      test "collects workflow keys from recurring tasks trigger states and direct workflow runs" do
         SolidQueue::RecurringTask.create!(
           key: "workflow:scheduled_workflow:schedule:123",
           schedule: "0 * * * *",
@@ -24,15 +22,9 @@ module R3x
           queue_name: "default",
           static: false
         )
-        R3x::TriggerState.create!(
-          workflow_key: "observed_workflow",
-          trigger_key: "feed:1",
-          trigger_type: "feed",
-          state: {}
-        )
         DashboardJobRows.create_job!(
-          job_class_name: observed_job_class_name,
-          arguments: [ "feed:1" ],
+          job_class_name: "Workflows::ObservedWorkflow",
+          arguments: [],
           finished_at: 1.minute.ago,
           created_at: 2.minutes.ago,
           updated_at: 1.minute.ago
@@ -112,6 +104,28 @@ module R3x
         assert_equal({ WORKFLOW_JOB_CLASS_NAME => "test_workflow" }, catalog.class_names_to_keys)
       end
 
+      test "ignores unrelated observed jobs without trigger_payload signature" do
+        SolidQueue::RecurringTask.create!(
+          key: "workflow:test_workflow:schedule:123",
+          schedule: "0 * * * *",
+          class_name: WORKFLOW_JOB_CLASS_NAME,
+          arguments: [ "schedule:123" ],
+          queue_name: "default",
+          static: false
+        )
+        DashboardJobRows.create_job!(
+          job_class_name: "CleanupJob",
+          arguments: [ "schedule:123" ],
+          finished_at: 1.minute.ago,
+          created_at: 2.minutes.ago,
+          updated_at: 1.minute.ago
+        )
+
+        catalog = Workflow::Catalog.new
+
+        refute_includes catalog.class_names_to_keys.keys, "CleanupJob"
+      end
+
       test "find raises for unknown workflow" do
         error = assert_raises(KeyError) do
           Workflow::Catalog.new.find!("missing_workflow")
@@ -121,17 +135,6 @@ module R3x
       end
 
       private
-        def ensure_dashboard_job_class(name)
-          test_jobs = if Object.const_defined?(:TestDashboardJobs, false)
-            Object.const_get(:TestDashboardJobs)
-          else
-            Object.const_set(:TestDashboardJobs, Module.new)
-          end
-
-          return test_jobs.const_get(name, false) if test_jobs.const_defined?(name, false)
-
-          test_jobs.const_set(name, Class.new(R3x::TestSupport::DashboardWorkflowJob))
-        end
     end
   end
 end

--- a/test/lib/r3x/dashboard/workflow_run_counts_test.rb
+++ b/test/lib/r3x/dashboard/workflow_run_counts_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 module R3x
   module Dashboard
     class WorkflowRunCountsTest < ActiveSupport::TestCase
-      WORKFLOW_JOB_CLASS_NAME = R3x::TestSupport::DashboardWorkflowJob.name.freeze
+      WORKFLOW_JOB_CLASS_NAME = DashboardTestWorkflows.ensure_class("TestWorkflow").freeze
 
       setup do
         TestDbCleanup.clear_runtime_tables!

--- a/test/lib/r3x/dashboard/workflow_run_enqueuer_test.rb
+++ b/test/lib/r3x/dashboard/workflow_run_enqueuer_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 module R3x
   module Dashboard
     class WorkflowRunEnqueuerTest < ActiveSupport::TestCase
-      WORKFLOW_JOB_CLASS_NAME = R3x::TestSupport::DashboardWorkflowJob.name.freeze
+      WORKFLOW_JOB_CLASS_NAME = DashboardTestWorkflows.ensure_class("TestWorkflow").freeze
 
       include ActiveJob::TestHelper
 

--- a/test/lib/r3x/dashboard/workflow_runs_test.rb
+++ b/test/lib/r3x/dashboard/workflow_runs_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 module R3x
   module Dashboard
     class WorkflowRunsTest < ActiveSupport::TestCase
-      WORKFLOW_JOB_CLASS_NAME = R3x::TestSupport::DashboardWorkflowJob.name.freeze
+      WORKFLOW_JOB_CLASS_NAME = DashboardTestWorkflows.ensure_class("TestWorkflow").freeze
 
       setup do
         TestDbCleanup.clear_runtime_tables!
@@ -28,6 +28,31 @@ module R3x
         assert_equal "test_workflow", run[:workflow_key]
         assert_equal "finished", run[:status]
         assert_equal "schedule:abc123", run[:trigger_key]
+        assert_equal job.created_at, run[:started_at]
+      end
+
+      test "started_at uses claimed_execution time for running jobs" do
+        job = DashboardJobRows.create_job!(
+          job_class_name: WORKFLOW_JOB_CLASS_NAME,
+          arguments: [ "schedule:abc123" ],
+          created_at: 5.minutes.ago,
+          updated_at: 2.minutes.ago
+        )
+        process = SolidQueue::Process.create!(
+          name: "test-worker-1",
+          kind: "Worker",
+          pid: $$,
+          hostname: "localhost",
+          last_heartbeat_at: Time.current,
+          created_at: Time.current
+        )
+        claimed_at = 2.minutes.ago
+        SolidQueue::ClaimedExecution.create!(job_id: job.id, process_id: process.id, created_at: claimed_at)
+
+        run = Workflow::Runs.new.all.find { |entry| entry[:job_id] == job.id }
+
+        assert_equal "running", run[:status]
+        assert_equal claimed_at.to_i, run[:started_at].to_i
       end
 
       test "maps trigger payload for workflow jobs" do
@@ -61,8 +86,6 @@ module R3x
       end
 
       test "maps change-detection-driven workflow runs through trigger state observations" do
-        observed_job_class_name = ensure_dashboard_job_class("FeedWorkflowJob").name
-
         R3x::TriggerState.create!(
           workflow_key: "feed_workflow",
           trigger_key: "feed:123",
@@ -70,7 +93,7 @@ module R3x
           state: {}
         )
         job = DashboardJobRows.create_job!(
-          job_class_name: observed_job_class_name,
+          job_class_name: "Workflows::FeedWorkflow",
           arguments: [ "feed:123", { trigger_payload: { "id" => "99" } } ],
           finished_at: 1.minute.ago,
           created_at: 5.minutes.ago,
@@ -195,18 +218,6 @@ module R3x
             queue_name: "default",
             static: false
           )
-        end
-
-        def ensure_dashboard_job_class(name)
-          test_jobs = if Object.const_defined?(:TestDashboardJobs, false)
-            Object.const_get(:TestDashboardJobs)
-          else
-            Object.const_set(:TestDashboardJobs, Module.new)
-          end
-
-          return test_jobs.const_get(name, false) if test_jobs.const_defined?(name, false)
-
-          test_jobs.const_set(name, Class.new(R3x::TestSupport::DashboardWorkflowJob))
         end
     end
   end

--- a/test/lib/r3x/dashboard/workflow_summaries_test.rb
+++ b/test/lib/r3x/dashboard/workflow_summaries_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 module R3x
   module Dashboard
     class WorkflowSummariesTest < ActiveSupport::TestCase
-      WORKFLOW_JOB_CLASS_NAME = R3x::TestSupport::DashboardWorkflowJob.name.freeze
+      WORKFLOW_JOB_CLASS_NAME = DashboardTestWorkflows.ensure_class("TestWorkflow").freeze
 
       setup do
         clear_tables
@@ -160,7 +160,7 @@ module R3x
       end
 
       test "last run summary follows recorded activity instead of newest enqueue time" do
-        job_class_name = ensure_dashboard_job_class("OverlapWorkflowJob").name
+        job_class_name = DashboardTestWorkflows.ensure_class("OverlapWorkflow")
 
         SolidQueue::RecurringTask.create!(
           key: "workflow:overlap_workflow:schedule:abc123",
@@ -200,7 +200,7 @@ module R3x
         end
 
         def create_dashboard_workflow(workflow_key:, trigger_key:, run_status: nil, recorded_at: nil, trigger_error_at: nil)
-          job_class_name = ensure_dashboard_job_class("#{workflow_key.camelize}Job").name
+          job_class_name = DashboardTestWorkflows.ensure_class(workflow_key.camelize)
 
           SolidQueue::RecurringTask.create!(
             key: "workflow:#{workflow_key}:#{trigger_key}",
@@ -235,18 +235,6 @@ module R3x
           return unless run_status == "failed"
 
           SolidQueue::FailedExecution.create!(job_id: job.id, error: "#{workflow_key} failed", created_at: recorded_at)
-        end
-
-        def ensure_dashboard_job_class(name)
-          test_jobs = if Object.const_defined?(:TestDashboardJobs, false)
-            Object.const_get(:TestDashboardJobs)
-          else
-            Object.const_set(:TestDashboardJobs, Module.new)
-          end
-
-          return test_jobs.const_get(name, false) if test_jobs.const_defined?(name, false)
-
-          test_jobs.const_set(name, Class.new(R3x::TestSupport::DashboardWorkflowJob))
         end
     end
   end

--- a/test/support/dashboard_test_workflows.rb
+++ b/test/support/dashboard_test_workflows.rb
@@ -1,0 +1,15 @@
+module Workflows
+  module Test
+  end
+end
+
+module DashboardTestWorkflows
+  extend self
+
+  def ensure_class(name)
+    return "Workflows::Test::#{name}" if Workflows::Test.const_defined?(name, false)
+
+    Workflows::Test.const_set(name, Class.new(R3x::TestSupport::DashboardWorkflowJob))
+    "Workflows::Test::#{name}"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "rails/test_help"
 require "webmock/minitest"
 require_relative "support/dashboard_job_rows"
 require_relative "support/dashboard_workflow_job"
+require_relative "support/dashboard_test_workflows"
 require_relative "support/vault_test_helpers"
 require_relative "support/test_db_cleanup"
 


### PR DESCRIPTION
## Summary

- Restricts `observed_triggers` scope to an empty whitelist since `R3x::RunWorkflowJob` was removed in PR #56. All workflow jobs are now direct (`Workflows::*`).
- Fallback `started_at` to `created_at` when `claimed_execution` is cleaned up by Solid Queue for finished/failed jobs.
- Removes the "Not started" conditional from the dashboard run detail UI.
- Introduces `DashboardTestWorkflows` helper for test workflow classes in `Workflows::Test::*` so `SolidQueue::RecurringTask` validation passes.
- Updates all dashboard tests to use the new helper and direct workflow class names.

## Related discussions

- https://github.com/r3x-dev/engine/pull/56#discussion_r3130802441
- https://github.com/r3x-dev/engine/pull/57#discussion_r3132864944