### PR TITLE
feat: structured error logging with backtrace for dashboard

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,6 @@
 class ApplicationJob < ActiveJob::Base
+  include R3x::StructuredLogging
+
   around_perform :tag_log_context
 
   private

--- a/app/jobs/r3x/change_detection_job.rb
+++ b/app/jobs/r3x/change_detection_job.rb
@@ -44,7 +44,7 @@ module R3x
         ("r3x.trigger_key=#{trigger_key}" if defined?(trigger_key) && trigger_key.present?),
         "r3x.job_outcome=failed"
       ) do
-        logger.error "Change detection failed error_class=#{e.class} error_message=#{e.message}"
+        structured_error(message: "Change detection failed", error: e)
       end
 
       raise

--- a/app/lib/r3x/dashboard/logs.rb
+++ b/app/lib/r3x/dashboard/logs.rb
@@ -102,7 +102,10 @@ module R3x
         payload = parse_message_payload(entry["_msg"], context: context)
 
         {
+          backtrace: Array(payload[:backtrace]).presence,
           container_name: entry["kubernetes.container_name"],
+          error_class: payload[:error_class],
+          error_message: payload[:error_message],
           level: payload.fetch(:level),
           message: payload.fetch(:message),
           pod_name: entry["kubernetes.pod_name"],
@@ -133,6 +136,9 @@ module R3x
         message, tags = extract_message_and_tags(parsed["message"], tags: parsed["tags"], context: context)
 
         {
+          backtrace: parsed["backtrace"],
+          error_class: parsed["error_class"],
+          error_message: parsed["error_message"],
           level: normalize_level(parsed["level"]),
           message: message,
           tags: tags

--- a/app/lib/r3x/structured_logging.rb
+++ b/app/lib/r3x/structured_logging.rb
@@ -1,0 +1,32 @@
+module R3x
+  module StructuredLogging
+    def structured_error(message:, error:)
+      return unless json_logging_enabled?
+
+      payload = {
+        level: "error",
+        time: Time.current.utc.iso8601(6),
+        message: message,
+        error_class: error.class.name,
+        error_message: error.message,
+        backtrace: error.backtrace&.first(20),
+        tags: current_log_tags
+      }
+      formatted = R3x::LogFormatter.new.call("error", Time.current, nil, payload)
+      Rails.logger << formatted
+    end
+
+    private
+
+    def current_log_tags
+      formatter = Rails.logger.formatter
+      return [] unless formatter.respond_to?(:tag_stack)
+
+      formatter.tag_stack.tags
+    end
+
+    def json_logging_enabled?
+      Rails.logger.formatter.is_a?(R3x::LogFormatter)
+    end
+  end
+end

--- a/app/lib/r3x/structured_logging.rb
+++ b/app/lib/r3x/structured_logging.rb
@@ -1,19 +1,21 @@
 module R3x
   module StructuredLogging
     def structured_error(message:, error:)
-      return unless json_logging_enabled?
-
-      payload = {
-        level: "error",
-        time: Time.current.utc.iso8601(6),
-        message: message,
-        error_class: error.class.name,
-        error_message: error.message,
-        backtrace: error.backtrace&.first(20),
-        tags: current_log_tags
-      }
-      formatted = R3x::LogFormatter.new.call("error", Time.current, nil, payload)
-      Rails.logger << formatted
+      if json_logging_enabled?
+        payload = {
+          level: "error",
+          time: Time.current.utc.iso8601(6),
+          message: message,
+          error_class: error.class.name,
+          error_message: error.message,
+          backtrace: error.backtrace&.first(20),
+          tags: current_log_tags
+        }
+        formatted = R3x::LogFormatter.new.call("error", Time.current, nil, payload)
+        Rails.logger << formatted
+      else
+        logger.error "#{message} error_class=#{error.class} error_message=#{error.message}"
+      end
     end
 
     private

--- a/app/views/r3x/dashboard/workflow_runs/show.html.erb
+++ b/app/views/r3x/dashboard/workflow_runs/show.html.erb
@@ -82,6 +82,27 @@
   <%= render "r3x/dashboard/workflow_runs/logs_panel", run: @run, logs: @logs %>
 <% end %>
 
+<% if @logs.present? && @logs[:entries].any? { |e| e[:backtrace].present? } %>
+  <section class="panel stack panel-spaced">
+    <div>
+      <h3 class="section-title">Backtrace</h3>
+    </div>
+    <% @logs[:entries].select { |e| e[:backtrace].present? }.each do |entry| %>
+      <% if entry[:error_class].present? || entry[:error_message].present? %>
+        <div class="failure-summary">
+          <% if entry[:error_class].present? %>
+            <span class="pill danger"><%= entry[:error_class] %></span>
+          <% end %>
+          <% if entry[:error_message].present? %>
+            <strong><%= entry[:error_message] %></strong>
+          <% end %>
+        </div>
+      <% end %>
+      <pre class="error-block"><%= entry[:backtrace].join("\n") %></pre>
+    <% end %>
+  </section>
+<% end %>
+
 <section class="panel stack panel-spaced">
   <details class="technical-details">
     <summary>Advanced details</summary>

--- a/config/log_formatter.rb
+++ b/config/log_formatter.rb
@@ -14,16 +14,24 @@ module R3x
     private
 
     def payload_for(severity, time, progname, msg)
-      message, tags = extract_message_and_tags(msg2str(msg))
-
-      {
+      base = {
         "level" => normalize_level(severity),
-        "message" => message,
         "time" => time.utc.iso8601(6)
-      }.tap do |payload|
-        payload["progname"] = progname if progname
-        payload["tags"] = tags if tags.any?
+      }
+      base["progname"] = progname if progname
+
+      case msg
+      when Hash
+        base.merge!(msg.transform_keys(&:to_s))
+      when String, Symbol, NilClass
+        message, tags = extract_message_and_tags(msg2str(msg))
+        base["message"] = message
+        base["tags"] = tags if tags.any?
+      else
+        raise ArgumentError, "Unsupported log message type: #{msg.class}"
       end
+
+      base
     end
 
     def normalize_level(severity)

--- a/lib/r3x/workflow/base.rb
+++ b/lib/r3x/workflow/base.rb
@@ -36,7 +36,7 @@ module R3x
             end
           rescue => e
             with_log_tags("r3x.job_outcome=failed") do
-              logger.error "Workflow run failed error_class=#{e.class} error_message=#{e.message}"
+              structured_error(message: "Workflow run failed", error: e)
             end
 
             raise

--- a/test/jobs/r3x/change_detection_job_test.rb
+++ b/test/jobs/r3x/change_detection_job_test.rb
@@ -175,7 +175,9 @@ module R3x
 
       assert_includes output, "r3x.job_outcome=failed"
       assert_includes output, "Change detection failed"
-      assert_includes output, "error_class=ArgumentError"
+      assert_includes output, "\"error_class\":\"ArgumentError\""
+      assert_includes output, "\"error_message\":\"detection failed\""
+      assert_includes output, "\"backtrace\":["
     end
 
     private

--- a/test/lib/r3x/dashboard/logs_test.rb
+++ b/test/lib/r3x/dashboard/logs_test.rb
@@ -204,6 +204,38 @@ module R3x
         assert_equal "valid line", result[:entries].first[:message]
       end
 
+      test "parses structured error fields from hash payload" do
+        client = FakeLogsClient.new(entries: [
+          {
+            "_time" => "2026-04-15T12:00:01Z",
+            "_msg" => MultiJson.dump(
+              "level" => "error",
+              "message" => "Workflow run failed",
+              "error_class" => "NameError",
+              "error_message" => "uninitialized constant",
+              "backtrace" => [ "app/lib/a.rb:1", "app/lib/b.rb:2" ]
+            ),
+            "kubernetes.container_name" => "app",
+            "kubernetes.pod_name" => "r3x-jobs-123"
+          }
+        ])
+
+        run = {
+          active_job_id: "aj-123",
+          enqueued_at: Time.zone.parse("2026-04-15T12:00:00Z"),
+          finished_at: Time.zone.parse("2026-04-15T12:00:30Z")
+        }
+
+        result = Logs.new(provider_name: "victorialogs", client: client).run_logs(run)
+        entry = result[:entries].first
+
+        assert_equal "error", entry[:level]
+        assert_equal "Workflow run failed", entry[:message]
+        assert_equal "NameError", entry[:error_class]
+        assert_equal "uninitialized constant", entry[:error_message]
+        assert_equal [ "app/lib/a.rb:1", "app/lib/b.rb:2" ], entry[:backtrace]
+      end
+
       test "returns provider error when provider is unsupported" do
         result = Logs.new(provider_name: "unknown").run_logs(active_job_id: "aj-123")
 

--- a/test/lib/r3x/dashboard/run_test.rb
+++ b/test/lib/r3x/dashboard/run_test.rb
@@ -185,8 +185,8 @@ class Dashboard::RunTest < ActiveSupport::TestCase
       assert_includes error.message, "Direct workflow enqueue failed"
     end
 
-    assert_includes output, "Dashboard direct enqueue failed"
-    assert_includes output, "error_class=SolidQueue::Job::EnqueueError"
+      assert_includes output, "Dashboard direct enqueue failed"
+      assert_includes output, "error_class=SolidQueue::Job::EnqueueError"
   end
 
   private

--- a/test/lib/r3x/log_formatter_test.rb
+++ b/test/lib/r3x/log_formatter_test.rb
@@ -50,5 +50,38 @@ module R3x
       assert_equal "[DRY-RUN]: email not sent", payload.fetch("message")
       refute payload.key?("tags")
     end
+
+    test "merges hash payload as top-level fields" do
+      io = StringIO.new
+      logger = ActiveSupport::Logger.new(io).tap do |base_logger|
+        base_logger.formatter = LogFormatter.new
+      end
+
+      logger.error(
+        message: "Workflow run failed",
+        error_class: "NameError",
+        error_message: "uninitialized constant",
+        backtrace: [ "app/lib/a.rb:1", "app/lib/b.rb:2" ]
+      )
+
+      payload = MultiJson.load(io.string)
+
+      assert_equal "error", payload.fetch("level")
+      assert_equal "Workflow run failed", payload.fetch("message")
+      assert_equal "NameError", payload.fetch("error_class")
+      assert_equal "uninitialized constant", payload.fetch("error_message")
+      assert_equal [ "app/lib/a.rb:1", "app/lib/b.rb:2" ], payload.fetch("backtrace")
+      assert_match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z\z/, payload.fetch("time"))
+    end
+
+    test "raises on unsupported message type" do
+      formatter = LogFormatter.new
+
+      error = assert_raises(ArgumentError) do
+        formatter.call("error", Time.current, nil, 12345)
+      end
+
+      assert_equal "Unsupported log message type: Integer", error.message
+    end
   end
 end

--- a/test/lib/r3x/workflow_test.rb
+++ b/test/lib/r3x/workflow_test.rb
@@ -486,7 +486,9 @@ module R3x
 
       assert_includes output, "r3x.job_outcome=failed"
       assert_includes output, "Workflow run failed"
-      assert_includes output, "error_class=ArgumentError"
+      assert_includes output, "\"error_class\":\"ArgumentError\""
+      assert_includes output, "\"error_message\":\"boom\""
+      assert_includes output, "\"backtrace\":["
     end
 
     test "prevents overriding perform method in subclasses" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,7 @@ module ActiveSupport
       original_active_job_logger = ActiveJob::Base.logger
       test_logger = ActiveSupport::TaggedLogging.new(
         ActiveSupport::Logger.new(io).tap do |logger|
-          logger.formatter = Rails.application.config.log_formatter || ::Logger::Formatter.new
+          logger.formatter = R3x::LogFormatter.new
         end
       )
 


### PR DESCRIPTION
## Summary
Emit structured error details (class, message, backtrace) as JSON log fields and surface them in the dashboard run view for faster failure diagnosis.

## Changes
- Add `R3x::StructuredLogging` concern for hash-based error logging
- Update `LogFormatter` to merge Hash payloads as top-level fields
- Parse structured error fields in `Dashboard::Logs` for display
- Render backtrace panel in workflow run detail page
- Update workflow and change detection jobs to use structured errors