### PR TITLE
feat(dashboard): unify hover feedback across nav, buttons and chips

### DIFF
--- a/app/views/layouts/r3x/dashboard.html.erb
+++ b/app/views/layouts/r3x/dashboard.html.erb
@@ -791,18 +791,20 @@
 
       .button,
       button,
-      .chip-link {
+      .chip-link,
+      .nav a:not(.current) {
         transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
       }
 
       .button:hover,
-      button:hover {
-        transform: scale(1.04);
+      button:hover,
+      .nav a:not(.current):hover {
+        transform: scale(1.03);
         box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
       }
 
       .chip-link:hover {
-        transform: scale(1.04);
+        transform: scale(1.03);
         box-shadow: 0 3px 10px rgba(0, 0, 0, 0.06);
       }
 


### PR DESCRIPTION
## Summary
Unify hover transitions across dashboard interactive elements and reduce scale intensity for a subtler effect.

## Changes
- Add `.nav a:not(.current)` to shared hover transition and transform rules
- Reduce hover scale from `1.04` to `1.03` for buttons, chip-links, and nav links