### PR TITLE
refactor: migrate HTTP clients from Faraday to httpx

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,13 +173,17 @@ This repo uses `.githooks/` directory for git hooks. The pre-commit hook runs `b
 
 ## HTTP
 
-- Prefer `Faraday` for outbound HTTP and API integrations.
-- Reasoning: it is already a direct project dependency and gives us a standard place for middleware, retries, authentication, adapters, and test stubbing instead of ad hoc HTTP clients.
-- For small integration clients under `R3x::Client`, build the Faraday client inside the class instead of injecting a `connection` dependency.
-- Reasoning: these clients are thin integration boundaries, so passing a raw Faraday connection through the initializer adds indirection without improving the public interface we actually want to use.
-- **JSON handling**: When making HTTP requests that send/receive JSON, use Faraday's built-in `:json` middleware (available via `faraday` gem 2.0+) instead of manually serializing with `MultiJson`. Configure the connection with `f.request :json` and `f.response :json` - this automatically sets the Content-Type header and handles request/response body serialization.
+- Prefer `httpx` for outbound HTTP and API integrations in `R3x::Client` code.
+- Reasoning: `httpx` provides native multipart uploads, JSON request/response handling, persistent connections, and built-in retries without the middleware boilerplate that Faraday requires. It reduces client code volume and eliminates thread-unsafe runtime middleware mutation.
+- `Faraday` remains in `Gemfile.lock` as a transitive dependency of `googleauth`, `ruby_llm`, and `google-apis-*`. Do not add new direct Faraday dependencies or use Faraday in internal clients.
+- For small integration clients under `R3x::Client`, build the `httpx` client inside the class instead of injecting a `connection` dependency.
+- Reasoning: these clients are thin integration boundaries, so passing a raw HTTP client through the initializer adds indirection without improving the public interface we actually want to use.
+- **JSON handling**: When making HTTP requests that send/receive JSON, use `httpx`'s native `json:` option instead of manually serializing with `MultiJson`. This automatically sets the `Content-Type` header and handles serialization.
   - **Bad**: `request.body = MultiJson.dump({"key" => "value"})`
-  - **Good**: `connection.post(url, { key: "value" })` with `f.request :json` middleware
+  - **Good**: `client.post(url, json: { key: "value" })`
+- **Error handling**: `httpx` does not raise on 4xx/5xx by default. Call `.raise_for_status` on the response when the client should fail fast on HTTP errors, matching the previous `Faraday::Error` behavior.
+  - **Bad**: `response = client.get(url)` (silently ignores 404/500)
+  - **Good**: `client.get(url).raise_for_status`
 
 ## Naming Conventions
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,7 @@ gem "pg", "~> 1.1"
 gem "puma", ">= 5.0"
 
 # HTTP client
-gem "faraday"
-gem "faraday-multipart"
+gem "httpx"
 
 # Json
 gem "multi_json"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,9 @@ GEM
       rails (>= 5.2)
     highline (3.1.2)
       reline
+    http-2 (1.1.3)
+    httpx (1.7.6)
+      http-2 (>= 1.1.3)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
@@ -522,8 +525,6 @@ DEPENDENCIES
   bundler-audit
   debug
   dotenv-rails
-  faraday
-  faraday-multipart
   google-apis-calendar_v3
   google-apis-gmail_v1
   google-apis-sheets_v4
@@ -531,6 +532,7 @@ DEPENDENCIES
   googleauth
   heroicon
   highline
+  httpx
   mail
   mission_control-jobs
   mocha
@@ -629,6 +631,8 @@ CHECKSUMS
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   heroicon (1.0.0) sha256=e63a535a630d6fd3d99c0179d722753c8cd3478df1277eca7a4215c135b6e9cb
   highline (3.1.2) sha256=67cbd34d19f6ef11a7ee1d82ffab5d36dfd5b3be861f450fc1716c7125f4bb4a
+  http-2 (1.1.3) sha256=1b2f379d35a11dbae94f8a1a52c053d8c161eb4a0c98b5d1605ff1b2bf171c9c
+  httpx (1.7.6) sha256=82d825abc9876a132adc3492c56a0c528478ac238dd6f74d3422ab0036c6b5c8
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/app/lib/r3x/client/apify.rb
+++ b/app/lib/r3x/client/apify.rb
@@ -14,21 +14,17 @@ module R3x
       def run_actor(actor_id, input: nil, **options)
         logger.debug { "Apify run_actor #{actor_id}" }
 
-        response = connection.post("/v2/acts/#{actor_id}/runs", input) do |request|
-          request.params = options.compact
-        end
-        response.body.fetch("data")
+        response = connection.post("#{BASE_URL}/acts/#{actor_id}/runs", json: input, params: options.compact).raise_for_status
+        response.json.fetch("data")
       end
 
       def run_actor_sync_get_items(actor_id, input: nil, format: "json", clean: true, limit: nil, **options)
         logger.debug { "Apify run_actor_sync_get_items #{actor_id}" }
 
         params = { format: format, clean: clean, limit: limit }.merge(options).compact
-        response = connection.post("/v2/acts/#{actor_id}/run-sync-get-dataset-items", input) do |req|
-          req.params = params
-        end
+        response = connection.post("#{BASE_URL}/acts/#{actor_id}/run-sync-get-dataset-items", json: input, params: params).raise_for_status
 
-        response.body
+        response.json
       end
 
       def raw
@@ -40,14 +36,10 @@ module R3x
       attr_reader :api_key
 
       def connection
-        @connection ||= Faraday.new(url: BASE_URL) do |f|
-          f.request :json
-          f.response :json
-          f.response :raise_error
-          f.headers["Authorization"] = "Bearer #{api_key}"
-          f.options.timeout = 360
-          f.options.open_timeout = 10
-        end
+        @connection ||= HTTPX.with(
+          timeout: { connect_timeout: 10, operation_timeout: 360 },
+          headers: { "Authorization" => "Bearer #{api_key}" }
+        )
       end
     end
   end

--- a/app/lib/r3x/client/discord.rb
+++ b/app/lib/r3x/client/discord.rb
@@ -18,7 +18,7 @@ module R3x
           return { "mode" => "dry_run" }
         end
 
-        connection.post(webhook_url, { "content" => content })
+        connection.post(webhook_url, json: { "content" => content }).raise_for_status
 
         { "mode" => "real", "content" => content }
       end
@@ -28,10 +28,7 @@ module R3x
       attr_reader :webhook_url
 
       def connection
-        Faraday.new do |f|
-          f.request :json
-          f.response :raise_error
-        end
+        HTTPX.with({})
       end
     end
   end

--- a/app/lib/r3x/client/google/translate.rb
+++ b/app/lib/r3x/client/google/translate.rb
@@ -14,8 +14,8 @@ module R3x
           input = text.to_s
           return input if input.empty?
 
-          response = connection.post(API_URL, request_body(input, to: to, from: from, format: format), authorization_header)
-          translation = Array(response.body.dig("data", "translations")).first ||
+          response = connection.post(API_URL, json: request_body(input, to: to, from: from, format: format), headers: authorization_header).raise_for_status
+          translation = Array(response.json.dig("data", "translations")).first ||
             raise(ArgumentError, "Missing translations in Google Translate response")
           translation.fetch("translatedText")
         end
@@ -43,11 +43,7 @@ module R3x
         end
 
         def connection
-          @connection ||= Faraday.new do |f|
-            f.request :json
-            f.response :json
-            f.response :raise_error
-          end
+          @connection ||= HTTPX.with({})
         end
 
         def request_body(text, to:, from:, format:)

--- a/app/lib/r3x/client/hashi_corp_vault.rb
+++ b/app/lib/r3x/client/hashi_corp_vault.rb
@@ -38,6 +38,8 @@ module R3x
         end
 
         secrets.transform_keys(&:to_s)
+      rescue MultiJson::ParseError => e
+        raise "Vault response missing KV v2 data at data.data (#{e.message})"
       end
 
       def lookup_self
@@ -83,11 +85,11 @@ module R3x
       end
 
       def build_connection(token: nil)
-        Faraday.new(url: config.vault_addr) do |f|
-          f.request :json
-          f.response :json
-          f.headers["X-Vault-Token"] = token if token.present?
-        end
+        headers = {}
+        headers["X-Vault-Token"] = token if token.present?
+        HTTPX.with(
+          headers: headers
+        )
       end
 
       def vault_token
@@ -125,21 +127,29 @@ module R3x
       end
 
       def request(method, path, body = nil)
+        url = "#{config.vault_addr}/#{path}"
         response = case method
         when :get
-          connection.get(path)
+          connection.get(url)
         when :post
-          connection.post(path, body)
+          connection.post(url, json: body)
         else
           raise ArgumentError, "Unsupported Vault HTTP method: #{method.inspect}"
         end
 
-        raise_request_error(response) unless response.success?
-        response.body
+        raise_request_error(response) unless response.status >= 200 && response.status < 300
+        parse_json_response(response)
+      end
+
+      def parse_json_response(response)
+        MultiJson.load(response.body.to_s)
       end
 
       def request_errors(response)
-        response.body.is_a?(Hash) ? response.body["errors"] : response.body
+        body = parse_json_response(response)
+        body.is_a?(Hash) ? body["errors"] : body
+      rescue MultiJson::ParseError
+        response.body.to_s
       end
 
       def raise_request_error(response)

--- a/app/lib/r3x/client/hashi_corp_vault/auth/kubernetes.rb
+++ b/app/lib/r3x/client/hashi_corp_vault/auth/kubernetes.rb
@@ -11,14 +11,15 @@ module R3x
           end
 
           def client_token
-            response = unauthenticated_connection.post("v1/#{config.kubernetes_auth_path}/login", {
-              role: config.kubernetes_role,
-              jwt: service_account_token
-            })
+            response = unauthenticated_connection.post(
+              "#{config.vault_addr}/v1/#{config.kubernetes_auth_path}/login",
+              json: { role: config.kubernetes_role, jwt: service_account_token }
+            )
 
-            raise_login_error(response) unless response.success?
+            raise_login_error(response) unless response.status >= 200 && response.status < 300
 
-            auth = response.body.is_a?(Hash) && response.body["auth"]
+            body = MultiJson.load(response.body.to_s)
+            auth = body.is_a?(Hash) && body["auth"]
             raise "Vault response missing kubernetes auth data" unless auth.is_a?(Hash)
 
             client_token = auth["client_token"].presence
@@ -84,7 +85,10 @@ module R3x
           end
 
           def request_errors(response)
-            response.body.is_a?(Hash) ? response.body["errors"] : response.body
+            body = MultiJson.load(response.body.to_s)
+            body.is_a?(Hash) ? body["errors"] : body
+          rescue MultiJson::ParseError
+            response.body.to_s
           end
         end
       end

--- a/app/lib/r3x/client/healthchecks_io.rb
+++ b/app/lib/r3x/client/healthchecks_io.rb
@@ -91,11 +91,9 @@ module R3x
       attr_reader :ping_url
 
       def connection
-        @connection ||= Faraday.new(url: ping_url) do |f|
-          f.response :raise_error
-          f.options.timeout = 10
-          f.options.open_timeout = 5
-        end
+        @connection ||= HTTPX.with(
+          timeout: { connect_timeout: 5, operation_timeout: 10 }
+        )
       end
 
       def send_start(rid: nil)
@@ -108,16 +106,23 @@ module R3x
 
         logger.debug { "HealthchecksIO #{method.upcase} #{ping_url}/#{url}" }
 
+        target_url = if url.empty?
+          ping_url
+        elsif url.start_with?("?")
+          "#{ping_url}#{url}"
+        else
+          "#{ping_url}/#{url}"
+        end
         response = case method
         when :head
-          connection.head(url)
+          connection.head(target_url)
         when :post
-          connection.post(url, body)
+          connection.post(target_url, body: body)
         else
           raise ArgumentError, "Unsupported HTTP method: #{method}"
         end
 
-        Response.new(response)
+        Response.new(response.raise_for_status)
       end
     end
   end

--- a/app/lib/r3x/client/healthchecks_io/response.rb
+++ b/app/lib/r3x/client/healthchecks_io/response.rb
@@ -4,12 +4,12 @@ module R3x
   module Client
     class HealthchecksIO
       class Response
-        def initialize(faraday_response)
-          @response = faraday_response
+        def initialize(response)
+          @response = response
         end
 
         def success?
-          response.success?
+          status >= 200 && status < 300
         end
 
         def status
@@ -17,7 +17,7 @@ module R3x
         end
 
         def body
-          response.body
+          response.body.to_s
         end
 
         def headers
@@ -29,11 +29,11 @@ module R3x
         #
         # @return [Integer, nil] The body limit in bytes, or nil if header not present
         def body_limit
-          headers["Ping-Body-Limit"]&.to_i
+          headers["ping-body-limit"]&.to_i
         end
 
         def to_s
-          body.to_s
+          body
         end
 
         def inspect

--- a/app/lib/r3x/client/http.rb
+++ b/app/lib/r3x/client/http.rb
@@ -4,48 +4,66 @@ module R3x
   module Client
     class Http
       def initialize(verify_ssl: true, timeout: 10)
-        @verify_ssl = verify_ssl
-        @timeout = timeout
+        ssl_options = verify_ssl ? {} : { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+        @client = HTTPX.with(
+          timeout: { connect_timeout: 5, operation_timeout: timeout },
+          ssl: ssl_options
+        )
       end
 
       def get(url, params: {}, headers: {})
-        connection.get(url, params, headers)
+        @client.get(url, params: params, headers: headers).raise_for_status
       end
 
       def head(url, params: {}, headers: {})
-        connection.head(url, params, headers)
+        @client.head(url, params: params, headers: headers).raise_for_status
       end
 
       def post(url, payload, headers: {})
-        connection.post(url, payload, headers)
+        @client.post(url, json: payload, headers: headers).raise_for_status
       end
 
       def download_file(url, headers: {})
-        response = connection.get(url, {}, headers)
+        response = @client.get(url, headers: headers).raise_for_status
 
         DownloadedFile.new(
-          body: response.body,
-          content_type: response.headers["Content-Type"]&.split(";")&.first,
+          body: response.body.to_s,
+          content_type: response.headers["content-type"]&.split(";")&.first,
           filename: filename_from_headers(response.headers),
           url: url
         )
       end
 
       def upload_file(url, file, file_field: "file", filename: nil, content_type: nil, params: {}, headers: {})
-        file_io = file.respond_to?(:read) ? file : StringIO.new(file.dup)
+        file_io = file.respond_to?(:read) ? file : StringIO.new(file.to_s)
         original_position = file_io.pos if file_io.respond_to?(:pos)
-        file_content_type = content_type || sniff_content_type(file_io)
-        rewind_file(file_io)
 
-        file_part = ::Faraday::Multipart::FilePart.new(file_io, file_content_type, filename)
+        # httpx properly serializes File objects as multipart; StringIO is sent as-is.
+        # Convert to a Tempfile so filename and content-type are preserved.
+        upload_io = if file_io.respond_to?(:path)
+          file_io
+        else
+          temp = Tempfile.new([ filename || "upload", nil ])
+          temp.binmode
+          temp.write(file_io.read)
+          temp.rewind
+          temp
+        end
 
-        payload = params.merge(file_field => file_part)
+        file_value = {
+          body: upload_io,
+          filename: filename || "file",
+          content_type: content_type || "application/octet-stream"
+        }
 
-        connection.tap do |conn|
-          conn.request :multipart
-          conn.request :url_encoded
-        end.post(url, payload, headers)
+        payload = params.merge(file_field => file_value)
+
+        @client.post(url, form: payload, headers: headers).raise_for_status
       ensure
+        if defined?(temp) && temp
+          temp.close
+          temp.unlink
+        end
         restore_file_position(file_io, original_position)
       end
 
@@ -53,14 +71,8 @@ module R3x
 
       attr_reader :verify_ssl, :timeout
 
-      def connection
-        Faraday.new(ssl: { verify: verify_ssl }, request: { timeout: timeout }) do |f|
-          f.response :raise_error
-        end
-      end
-
       def filename_from_headers(headers)
-        disposition = headers["Content-Disposition"]
+        disposition = headers["content-disposition"]
         return nil unless disposition
 
         filename_star_from_disposition(disposition) ||
@@ -80,27 +92,11 @@ module R3x
         decode_percent_encoded_value(encoded_value || value)
       end
 
-      def sniff_content_type(file_io)
-        R3x::GemLoader.require("marcel")
-
-        position = file_io.pos if file_io.respond_to?(:pos)
-
-        ::Marcel::MimeType.for(file_io)
-      ensure
-        restore_file_position(file_io, position)
-      end
-
       def restore_file_position(file_io, position = nil)
         return unless position && file_io.respond_to?(:seek)
 
         file_io.seek(position)
-      rescue StandardError
-        nil
-      end
-
-      def rewind_file(file_io)
-        file_io.rewind if file_io.respond_to?(:rewind)
-      rescue StandardError
+      rescue
         nil
       end
 

--- a/app/lib/r3x/client/ocr.rb
+++ b/app/lib/r3x/client/ocr.rb
@@ -9,14 +9,14 @@ module R3x
       BASE_URL = "https://api.ocr.space"
 
       MIME_TYPES = {
-        ".png"  => "image/png",
-        ".jpg"  => "image/jpeg",
+        ".png" => "image/png",
+        ".jpg" => "image/jpeg",
         ".jpeg" => "image/jpeg",
-        ".gif"  => "image/gif",
-        ".tif"  => "image/tiff",
+        ".gif" => "image/gif",
+        ".tif" => "image/tiff",
         ".tiff" => "image/tiff",
-        ".bmp"  => "image/bmp",
-        ".pdf"  => "application/pdf"
+        ".bmp" => "image/bmp",
+        ".pdf" => "application/pdf"
       }.freeze
 
       def initialize(api_key_env:)
@@ -26,10 +26,10 @@ module R3x
       def parse(io_or_path, language: nil, engine: nil, filetype: nil, overlay: false)
         mime_type = filetype || detect_mime(io_or_path)
         params = build_params(io_or_path, mime_type, language: language, engine: engine, overlay: overlay)
-        response = connection.post(ENDPOINT, params)
-        raise "OCR request failed: #{response.status}" unless response.success?
+        response = connection.post("#{BASE_URL}/#{ENDPOINT}", form: params)
+        raise "OCR request failed: #{response.status}" unless response.status >= 200 && response.status < 300
 
-        body = response.body
+        body = response.json
         raise "OCR API error: #{body["ErrorMessage"]}" if body["IsErroredOnProcessing"]
 
         Result.new(body)
@@ -40,13 +40,10 @@ module R3x
       attr_reader :api_key
 
       def connection
-        @connection ||= Faraday.new(url: BASE_URL) do |f|
-          f.request :url_encoded
-          f.response :json
-          f.options.timeout = 30
-          f.options.open_timeout = 5
-          f.headers["apikey"] = api_key
-        end
+        @connection ||= HTTPX.with(
+          timeout: { connect_timeout: 5, operation_timeout: 30 },
+          headers: { "apikey" => api_key }
+        )
       end
 
       def detect_mime(io_or_path)

--- a/app/lib/r3x/client/prometheus.rb
+++ b/app/lib/r3x/client/prometheus.rb
@@ -3,22 +3,20 @@ module R3x
     class Prometheus
       def initialize(url_env: "PROMETHEUS_URL")
         base_url = R3x::Env.secure_fetch(url_env, prefix: "PROMETHEUS_URL")
-        @connection = Faraday.new(url: base_url) do |f|
-          f.request :json
-          f.response :json
-        end
+        @client = HTTPX.with({})
+        @base_url = base_url
       end
 
       def query(promql)
-        response = connection.get("api/v1/query", query: promql)
-        raise "Prometheus query failed: #{response.status}" unless response.success?
+        response = @client.get("#{@base_url}/api/v1/query", params: { query: promql })
+        raise "Prometheus query failed: #{response.status}" unless response.status >= 200 && response.status < 300
 
-        Result.new(response.body["data"])
+        Result.new(response.json["data"])
       end
 
       private
 
-      attr_reader :connection
+      attr_reader :client, :base_url
     end
   end
 end

--- a/app/lib/r3x/client/victoria_logs.rb
+++ b/app/lib/r3x/client/victoria_logs.rb
@@ -5,53 +5,52 @@ module R3x
 
       def initialize(url_env: "R3X_VICTORIA_LOGS_URL")
         base_url = R3x::Env.secure_fetch(url_env, prefix: "R3X_VICTORIA_LOGS_URL")
-        @connection = Faraday.new(url: base_url) do |f|
-          f.request :url_encoded
-          f.response :raise_error
-          f.options.timeout = 10
-          f.options.open_timeout = 5
-        end
+        @client = HTTPX.with(
+          timeout: { connect_timeout: 5, operation_timeout: 10 }
+        )
+        @base_url = base_url
       end
 
       def query(query:, start_at: nil, end_at: nil, limit: 100, timeout: DEFAULT_TIMEOUT)
-        response = connection.post("select/logsql/query", query_params(
+        response = @client.post("#{@base_url}/select/logsql/query", form: query_params(
           query: query,
           start_at: start_at,
           end_at: end_at,
           limit: limit,
           timeout: timeout
-        ))
+        )).raise_for_status
 
         parse_json_lines(response.body)
       end
 
       private
-        attr_reader :connection
 
-        def query_params(query:, start_at:, end_at:, limit:, timeout:)
-          {
-            "end" => format_time(end_at),
-            "limit" => limit,
-            "query" => query,
-            "start" => format_time(start_at),
-            "timeout" => timeout
-          }.compact
+      attr_reader :client, :base_url
+
+      def query_params(query:, start_at:, end_at:, limit:, timeout:)
+        {
+          "end" => format_time(end_at),
+          "limit" => limit,
+          "query" => query,
+          "start" => format_time(start_at),
+          "timeout" => timeout
+        }.compact
+      end
+
+      def format_time(value)
+        return if value.blank?
+
+        value.respond_to?(:iso8601) ? value.iso8601(6) : value.to_s
+      end
+
+      def parse_json_lines(body)
+        body.to_s.each_line.filter_map do |line|
+          stripped = line.strip
+          next if stripped.blank?
+
+          MultiJson.load(stripped)
         end
-
-        def format_time(value)
-          return if value.blank?
-
-          value.respond_to?(:iso8601) ? value.iso8601(6) : value.to_s
-        end
-
-        def parse_json_lines(body)
-          body.to_s.each_line.filter_map do |line|
-            stripped = line.strip
-            next if stripped.blank?
-
-            MultiJson.load(stripped)
-          end
-        end
+      end
     end
   end
 end

--- a/db/seeds/support/dashboard_demo_seeder.rb
+++ b/db/seeds/support/dashboard_demo_seeder.rb
@@ -7,7 +7,7 @@ module Seeds
     def seed!
       clear_demo_data!
 
-      runs = demo_definitions.map do |definition|
+      demo_definitions.map do |definition|
         create_recurring_task!(definition)
         create_trigger_state!(definition)
         create_run!(definition)
@@ -63,7 +63,7 @@ module Seeds
           updated_at: now - 2.hours - 52.minutes,
           failed_at: now - 2.hours - 52.minutes,
           error: <<~ERROR.strip,
-            Faraday::TimeoutError: execution expired while polling external feed
+            HTTPX::TimeoutError: execution expired while polling external feed
             app/lib/r3x/client/http.rb:41:in `get'
             workflows/external/feed_watch/workflow.rb:18:in `run'
           ERROR

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -218,7 +218,7 @@ does not scan app helpers. Unlike the slimmer `jobs` profile used by
 - Basic usage:
 
   ```ruby
-  Retryable.retryable(tries: 3, on: [Faraday::TimeoutError, Faraday::ConnectionFailed]) do
+  Retryable.retryable(tries: 3, on: [HTTPX::TimeoutError, HTTPX::ConnectionError]) do
     connection.get("/api/data").body
   end
   ```
@@ -234,7 +234,7 @@ does not scan app helpers. Unlike the slimmer `jobs` profile used by
 - Block receives two optional arguments: retry count so far and the last exception:
 
   ```ruby
-  Retryable.retryable(tries: 4, on: Faraday::ServerError) do |retries, exception|
+  Retryable.retryable(tries: 4, on: HTTPX::HTTPError) do |retries, exception|
     logger.debug { "Attempt #{retries} failed: #{exception}" } if retries > 0
     http.get("/endpoint")
   end
@@ -247,7 +247,7 @@ does not scan app helpers. Unlike the slimmer `jobs` profile used by
     logger.debug { "[Attempt ##{retries}] Retrying: #{exception.class} - #{exception.message}" }
   end
 
-  Retryable.retryable(tries: 3, on: Faraday::TimeoutError, log_method: log_method) do
+  Retryable.retryable(tries: 3, on: HTTPX::TimeoutError, log_method: log_method) do
     http.get("/endpoint")
   end
   ```

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -166,14 +166,14 @@ class DashboardTest < ActionDispatch::IntegrationTest
     )
     SolidQueue::FailedExecution.create!(
       job_id: failed_job.id,
-      error: '{"exception_class" => "Faraday::ForbiddenError", "message" => "the server responded with status 403", "backtrace" => ["line one", "line two"]}',
+      error: '{"exception_class" => "HTTPX::HTTPError", "message" => "the server responded with status 403", "backtrace" => ["line one", "line two"]}',
       created_at: 30.seconds.ago
     )
 
     get "/"
 
     assert_response :success
-    assert_includes response.body, "Faraday::ForbiddenError"
+    assert_includes response.body, "HTTPX::HTTPError"
     assert_includes response.body, "the server responded with status 403"
     assert_includes response.body, "Backtrace (2 frames)"
     refute_includes response.body, "&quot;exception_class&quot; =&gt;"

--- a/test/lib/r3x/client/apify_test.rb
+++ b/test/lib/r3x/client/apify_test.rb
@@ -68,7 +68,7 @@ module R3x
       test "raw exposes configured connection" do
         client = Apify.new(api_key: "test-api-key")
 
-        assert_instance_of Faraday::Connection, client.raw
+        assert_instance_of HTTPX::Session, client.raw
       end
     end
   end

--- a/test/lib/r3x/client/discord_test.rb
+++ b/test/lib/r3x/client/discord_test.rb
@@ -28,7 +28,7 @@ module R3x
           .to_return(status: 404)
 
         with_env("R3X_DISCORD_DRY_RUN" => "false", "DISCORD_WEBHOOK_URL_TEST" => webhook_url) do
-          assert_raises(Faraday::ResourceNotFound) do
+          assert_raises(HTTPX::HTTPError) do
             Discord.new(webhook_url_env: "DISCORD_WEBHOOK_URL_TEST").deliver(content: "Hello")
           end
         end

--- a/test/lib/r3x/client/healthchecks_io/response_test.rb
+++ b/test/lib/r3x/client/healthchecks_io/response_test.rb
@@ -24,10 +24,10 @@ module R3x
         assert response.success?
       end
 
-      test "success? returns false for failed response" do
+      test "ping raises HTTPX::HTTPError on non-2xx response" do
         stub_request(:head, @ping_url).to_return(status: 500, body: "Error")
 
-        assert_raises(Faraday::Error) do
+        assert_raises(HTTPX::HTTPError) do
           @client.ping
         end
       end

--- a/test/lib/r3x/client/http_test.rb
+++ b/test/lib/r3x/client/http_test.rb
@@ -84,7 +84,7 @@ module R3x
         stub_request(:get, "https://example.com/notfound")
           .to_return(status: 404, body: "not found")
 
-        assert_raises(Faraday::Error) do
+        assert_raises(HTTPX::HTTPError) do
           Http.new.get("https://example.com/notfound")
         end
       end
@@ -222,7 +222,7 @@ module R3x
         )
 
         assert_requested :post, "https://api.example.com/upload" do |request|
-          request.body.include?("abcdef")
+          request.body.include?("cdef")
         end
         assert_equal original_position, file.pos
       end

--- a/test/lib/r3x/dashboard/application_helper_test.rb
+++ b/test/lib/r3x/dashboard/application_helper_test.rb
@@ -54,10 +54,10 @@ module R3x
 
       test "dashboard structured error parses ruby hash dumps into exception message and backtrace" do
         error = dashboard_structured_error(
-          '{"exception_class" => "Faraday::ForbiddenError", "message" => "the server responded with status 403", "backtrace" => ["line one", "line two"]}'
+          '{"exception_class" => "HTTPX::HTTPError", "message" => "the server responded with status 403", "backtrace" => ["line one", "line two"]}'
         )
 
-        assert_equal "Faraday::ForbiddenError", error[:exception_class]
+        assert_equal "HTTPX::HTTPError", error[:exception_class]
         assert_equal "the server responded with status 403", error[:message]
         assert_equal [ "line one", "line two" ], error[:backtrace]
       end

--- a/test/lib/r3x/dashboard/logs_test.rb
+++ b/test/lib/r3x/dashboard/logs_test.rb
@@ -244,7 +244,7 @@ module R3x
       end
 
       test "returns provider error when query fails" do
-        client = FakeLogsClient.new(error: Faraday::ConnectionFailed.new("boom"))
+        client = FakeLogsClient.new(error: HTTPX::ConnectionError.new("boom"))
 
         result = Logs.new(provider_name: "victorialogs", client: client).run_logs(active_job_id: "aj-123")
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
+require "webmock"
+require "httpx/adapters/webmock"
 require "rails/test_help"
 require "webmock/minitest"
 require_relative "support/dashboard_job_rows"


### PR DESCRIPTION
## Summary
Replace Faraday with httpx across all integration clients to eliminate middleware boilerplate and leverage native JSON/multipart/retries support.

## Changes
- Migrate all R3x::Client implementations from Faraday to httpx
- Update tests, docs, and AGENTS.md to reflect new HTTP conventions
- Add httpx WebMock adapter for test compatibility