### PR TITLE
feat: add ruby_llm automatic retry with global and per-workflow config

### DIFF
--- a/app/lib/r3x/client/llm.rb
+++ b/app/lib/r3x/client/llm.rb
@@ -1,11 +1,14 @@
 module R3x
   module Client
     class Llm
-      def initialize(api_key:, config_api_key_attr:)
+      def initialize(api_key:, config_api_key_attr:, max_retries: nil, retry_interval: nil, retry_backoff_factor: nil)
         R3x::GemLoader.require("ruby_llm")
 
         @llm_context = RubyLLM.context do |config|
           config.public_send(:"#{config_api_key_attr}=", api_key)
+          config.max_retries = max_retries if max_retries
+          config.retry_interval = retry_interval if retry_interval
+          config.retry_backoff_factor = retry_backoff_factor if retry_backoff_factor
         end
       end
 

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "ruby_llm"
+
+RubyLLM.configure do |config|
+  config.max_retries = 3
+  config.retry_interval = 60.0
+  config.retry_backoff_factor = 2
+end

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -252,24 +252,46 @@ does not scan app helpers. Unlike the slimmer `jobs` profile used by
   end
   ```
 
-- For fixed backoff windows (for example 1 minute and then 3 minutes), use a `sleep` lambda and log
-  the wait:
-
-  ```ruby
-  delays = [1.minute, 3.minutes]
-  tries = delays.size + 1
-
-  sleep_strategy = lambda do |retries|
-    delay = delays.fetch(retries, delays.last)
-    logger.info("Retrying in #{delay.inspect} (next attempt #{retries + 2}/#{tries})")
-    delay
-  end
-
-  Retryable.retryable(tries: tries, matching: /high demand/i, sleep: sleep_strategy) do
-    call_llm
-  end
-  ```
-
 - Avoid retrying operations that are not idempotent or that cause external side effects (e.g.
   sending emails, creating records) unless the remote API guarantees idempotency.
 - Full documentation: https://github.com/nfedyashev/retryable
+
+## LLM Retry
+
+`ruby_llm` has built-in automatic retry through its Faraday middleware. It is configured
+once in `config/initializers/ruby_llm.rb` and applies to all LLM calls automatically.
+
+The global defaults are:
+
+- `max_retries: 3`
+- `retry_interval: 60.0` (seconds)
+- `retry_backoff_factor: 2`
+
+This means the first retry waits 60 seconds, the second waits 120 seconds, then it gives up.
+The gem automatically retries on transient provider errors:
+
+- `RubyLLM::RateLimitError` (HTTP 429)
+- `RubyLLM::ServerError` (HTTP 500)
+- `RubyLLM::ServiceUnavailableError` (HTTP 502-504)
+- `RubyLLM::OverloadedError` (HTTP 529)
+- Network timeouts and connection failures
+
+### Per-workflow override
+
+If a particular workflow needs different retry behavior, pass overrides directly to
+`ctx.client.llm(...)`:
+
+```ruby
+response = ctx.client.llm(
+  api_key_env: "GEMINI_API_KEY_MICHAL",
+  max_retries: 5,
+  retry_interval: 30.0
+).message(
+  model: "gemini-3-flash-preview",
+  prompt: prompt
+)
+```
+
+Any option passed this way overrides the global default for that single `R3x::Client::Llm`
+instance. The rest of the call stays the same -- the retry is handled transparently by
+`ruby_llm`.

--- a/lib/r3x/workflow/context/client.rb
+++ b/lib/r3x/workflow/context/client.rb
@@ -16,10 +16,13 @@ module R3x
           R3x::Client::Apify.new(api_key: R3x::Env.secure_fetch(api_key_env, prefix: "APIFY_API_KEY"))
         end
 
-        def llm(api_key_env:)
+        def llm(api_key_env:, max_retries: nil, retry_interval: nil, retry_backoff_factor: nil)
           R3x::Client::Llm.new(
             api_key: R3x::Env.secure_fetch(api_key_env, prefix: /\A[A-Z]+_API_KEY_[A-Z0-9_]+\z/),
-            config_api_key_attr: "#{api_key_env.split("_").first.downcase}_api_key"
+            config_api_key_attr: "#{api_key_env.split("_").first.downcase}_api_key",
+            max_retries: max_retries,
+            retry_interval: retry_interval,
+            retry_backoff_factor: retry_backoff_factor
           )
         end
 


### PR DESCRIPTION
## Summary
Leverages ruby_llm's built-in Faraday retry middleware instead of manual retry blocks, providing automatic resilience against transient LLM provider errors with sensible defaults while preserving per-workflow override flexibility.

## Changes
- Add `max_retries`, `retry_interval`, `retry_backoff_factor` to `R3x::Client::Llm` and `ctx.client.llm(...)`
- Add global ruby_llm initializer with sensible defaults (3 retries, 60s base interval, 2x backoff)
- Replace manual `Retryable.retryable` example in docs with ruby_llm native retry documentation