### PR TITLE
fix: move ruby_llm retry config to lazy-load boundary

### DIFF
--- a/app/lib/r3x/client/llm.rb
+++ b/app/lib/r3x/client/llm.rb
@@ -4,6 +4,12 @@ module R3x
       def initialize(api_key:, config_api_key_attr:, max_retries: nil, retry_interval: nil, retry_backoff_factor: nil)
         R3x::GemLoader.require("ruby_llm")
 
+        RubyLLM.configure do |config|
+          config.max_retries = 3
+          config.retry_interval = 60.0
+          config.retry_backoff_factor = 2
+        end
+
         @llm_context = RubyLLM.context do |config|
           config.public_send(:"#{config_api_key_attr}=", api_key)
           config.max_retries = max_retries if max_retries

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "ruby_llm"
-
-RubyLLM.configure do |config|
-  config.max_retries = 3
-  config.retry_interval = 60.0
-  config.retry_backoff_factor = 2
-end

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -258,8 +258,9 @@ does not scan app helpers. Unlike the slimmer `jobs` profile used by
 
 ## LLM Retry
 
-`ruby_llm` has built-in automatic retry through its Faraday middleware. It is configured
-once in `config/initializers/ruby_llm.rb` and applies to all LLM calls automatically.
+`ruby_llm` has built-in automatic retry through its Faraday middleware. The defaults are
+applied when `R3x::Client::Llm` lazy-loads the gem, so processes that never call `ctx.client.llm`
+do not pay the boot or memory cost.
 
 The global defaults are:
 


### PR DESCRIPTION
## Summary

Addresses review feedback on #65: the `config/initializers/ruby_llm.rb` unconditionally `require`d `ruby_llm`, forcing the gem into every boot path (web/jobs/workflow_cli) even when no workflow uses `ctx.client.llm`.

## Changes

- Remove `config/initializers/ruby_llm.rb`
- Apply retry defaults inside `R3x::Client::Llm` at the lazy-load boundary
- Use idiomatic `RubyLLM.configure { |config| ... }` block syntax
- Update docs to reflect the new location