### PR TITLE
fix: apply ruby_llm retry defaults per-context instead of globally

### DIFF
--- a/app/lib/r3x/client/llm.rb
+++ b/app/lib/r3x/client/llm.rb
@@ -4,17 +4,11 @@ module R3x
       def initialize(api_key:, config_api_key_attr:, max_retries: nil, retry_interval: nil, retry_backoff_factor: nil)
         R3x::GemLoader.require("ruby_llm")
 
-        RubyLLM.configure do |config|
-          config.max_retries = 3
-          config.retry_interval = 60.0
-          config.retry_backoff_factor = 2
-        end
-
         @llm_context = RubyLLM.context do |config|
           config.public_send(:"#{config_api_key_attr}=", api_key)
-          config.max_retries = max_retries if max_retries
-          config.retry_interval = retry_interval if retry_interval
-          config.retry_backoff_factor = retry_backoff_factor if retry_backoff_factor
+          config.max_retries = max_retries || 3
+          config.retry_interval = retry_interval || 60.0
+          config.retry_backoff_factor = retry_backoff_factor || 2
         end
       end
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -258,11 +258,11 @@ does not scan app helpers. Unlike the slimmer `jobs` profile used by
 
 ## LLM Retry
 
-`ruby_llm` has built-in automatic retry through its Faraday middleware. The defaults are
-applied when `R3x::Client::Llm` lazy-loads the gem, so processes that never call `ctx.client.llm`
-do not pay the boot or memory cost.
+`ruby_llm` has built-in automatic retry through its Faraday middleware. Defaults are applied
+per `RubyLLM::Context` inside `R3x::Client::Llm`, so every workflow run gets an isolated copy.
+Processes that never call `ctx.client.llm` do not load the gem at all.
 
-The global defaults are:
+The defaults are:
 
 - `max_retries: 3`
 - `retry_interval: 60.0` (seconds)
@@ -293,6 +293,6 @@ response = ctx.client.llm(
 )
 ```
 
-Any option passed this way overrides the global default for that single `R3x::Client::Llm`
+Any option passed this way overrides the default for that single `R3x::Client::Llm`
 instance. The rest of the call stays the same -- the retry is handled transparently by
 `ruby_llm`.


### PR DESCRIPTION
## Summary

Follow-up to #66 review feedback: `RubyLLM.configure` inside `Llm#initialize` reset process-wide retry settings on every client creation, silently clobbering any runtime/global override.

## Changes

- Remove `RubyLLM.configure` call from `Llm#initialize`
- Apply defaults directly in the `RubyLLM.context` block using `||` fallbacks
- Each workflow run gets an isolated config copy — no global state mutation
- Runtime overrides (from initializers, console, tests) are preserved
- Docs updated to describe per-context semantics