### PR TITLE
refactor: only override retry_interval in ruby_llm context block

### DIFF
--- a/app/lib/r3x/client/llm.rb
+++ b/app/lib/r3x/client/llm.rb
@@ -6,9 +6,9 @@ module R3x
 
         @llm_context = RubyLLM.context do |config|
           config.public_send(:"#{config_api_key_attr}=", api_key)
-          config.max_retries = max_retries || 3
           config.retry_interval = retry_interval || 60.0
-          config.retry_backoff_factor = retry_backoff_factor || 2
+          config.max_retries = max_retries if max_retries
+          config.retry_backoff_factor = retry_backoff_factor if retry_backoff_factor
         end
       end
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -262,11 +262,8 @@ does not scan app helpers. Unlike the slimmer `jobs` profile used by
 per `RubyLLM::Context` inside `R3x::Client::Llm`, so every workflow run gets an isolated copy.
 Processes that never call `ctx.client.llm` do not load the gem at all.
 
-The defaults are:
-
-- `max_retries: 3`
-- `retry_interval: 60.0` (seconds)
-- `retry_backoff_factor: 2`
+The only project-level override is `retry_interval: 60.0` (the gem default is `0.1`).
+Everything else uses the gem defaults (`max_retries: 3`, `retry_backoff_factor: 2`).
 
 This means the first retry waits 60 seconds, the second waits 120 seconds, then it gives up.
 The gem automatically retries on transient provider errors:


### PR DESCRIPTION
## Summary

Review feedback: remove redundant || fallbacks for max_retries and retry_backoff_factor.
The gem already defaults those values (3 and 2), so only retry_interval needs a project-level override (60s instead of 0.1s).

## Changes

- Simplify `R3x::Client::Llm#initialize` to only override `retry_interval`
- Leave `max_retries` and `retry_backoff_factor` at gem defaults unless caller passes explicit overrides
- Update docs to reflect this