### PR TITLE
test: add retry override validation for R3x::Client::Llm

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -262,8 +262,8 @@ does not scan app helpers. Unlike the slimmer `jobs` profile used by
 per `RubyLLM::Context` inside `R3x::Client::Llm`, so every workflow run gets an isolated copy.
 Processes that never call `ctx.client.llm` do not load the gem at all.
 
-The only project-level override is `retry_interval: 60.0` (the gem default is `0.1`).
-Everything else uses the gem defaults (`max_retries: 3`, `retry_backoff_factor: 2`).
+The retry defaults are set in `app/lib/r3x/client/llm.rb` inside the `RubyLLM.context` block.
+Only `retry_interval` has a project-level override (the gem default is `0.1`); everything else uses the gem defaults.
 
 This means the first retry waits 60 seconds, the second waits 120 seconds, then it gives up.
 The gem automatically retries on transient provider errors:

--- a/test/lib/r3x/client/llm_test.rb
+++ b/test/lib/r3x/client/llm_test.rb
@@ -7,6 +7,28 @@ module R3x
         llm = Llm.new(api_key: "test-key", config_api_key_attr: "gemini_api_key")
         assert_not_nil llm
       end
+
+      test "applies project-level retry_interval default" do
+        llm = Llm.new(api_key: "test", config_api_key_attr: "gemini_api_key")
+        context = llm.instance_variable_get(:@llm_context)
+
+        assert_equal 60.0, context.config.retry_interval
+      end
+
+      test "forwards per-workflow retry overrides" do
+        llm = Llm.new(
+          api_key: "test",
+          config_api_key_attr: "gemini_api_key",
+          max_retries: 5,
+          retry_interval: 30.0,
+          retry_backoff_factor: 4
+        )
+        context = llm.instance_variable_get(:@llm_context)
+
+        assert_equal 5, context.config.max_retries
+        assert_equal 30.0, context.config.retry_interval
+        assert_equal 4, context.config.retry_backoff_factor
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Add test coverage for ruby_llm retry configuration in R3x::Client::Llm.

## Changes

- `test/lib/r3x/client/llm_test.rb`: verify `retry_interval` default (60.0) and per-workflow overrides
- `docs/workflows.md`: point to source file instead of hardcoding values