### PR TITLE
Fix scheduled previous run lookup

### DIFF
--- a/app/models/dashboard/recurring_task.rb
+++ b/app/models/dashboard/recurring_task.rb
@@ -13,6 +13,10 @@ module Dashboard
     end
 
     class << self
+      def find_by_workflow_and_trigger_key(workflow_key:, trigger_key:)
+        find_by(key: workflow_task_key(workflow_key, trigger_key))
+      end
+
       def find_by_workflow_and_trigger_key!(workflow_key:, trigger_key:)
         find_by!(key: workflow_task_key(workflow_key, trigger_key))
       end
@@ -38,6 +42,12 @@ module Dashboard
 
     def direct_workflow_class_name
       class_name.presence
+    end
+
+    def previous_run_at(active_job_id: nil)
+      executions = SolidQueue::RecurringExecution.where(task_key: key)
+      executions = executions.joins(:job).where.not(SolidQueue::Job.table_name => { active_job_id: }) if active_job_id.present?
+      executions.maximum(:run_at)
     end
 
     private

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -76,17 +76,19 @@ This violates SRP and makes every Solid Queue / error-format / UI change touch t
 
 ---
 
-### [ ] F. Coupling `lib/r3x/workflow/` to Solid Queue internals
+### [x] F. Keep workflow execution reads behind the Solid Queue boundary
 
-**File:** `lib/r3x/workflow/execution.rb:25`
+**Files:**
 
-```ruby
-@recurring_task = SolidQueue::RecurringTask.find_by(key: @workflow_key)
-```
+- `lib/r3x/workflow/execution.rb`
+- `app/models/dashboard/recurring_task.rb`
+- `lib/r3x/workflow/context.rb`
+- `lib/r3x/workflow/executor.rb`
+- `test/lib/r3x/workflow/context_test.rb`
 
-`AGENTS.md` points to `app/models/dashboard/` as the boundary over `solid_queue_*`. Framework code in `lib/r3x/workflow/` should not query Solid Queue internal tables directly.
+`R3x::Workflow::Execution#previous_run_at` used to look up `SolidQueue::RecurringTask` by bare `workflow_key`, but schedulable workflow tasks are persisted as `workflow:<workflow_key>:<trigger_key>`. The lookup also must exclude the currently running recurring execution because Solid Queue records it before the workflow job performs.
 
-**Suggested fix:** introduce a small adapter/repository, e.g. `Dashboard::RecurringTask.find_by_workflow_key(...)`, or pass `previous_run_at` from a higher layer.
+**Done:** `Executor` passes the resolved trigger key and Active Job id through `Context` into `Execution`, and `Execution#previous_run_at` delegates to `Dashboard::RecurringTask` so the namespaced key format and current-run exclusion live at the Solid Queue boundary.
 
 ---
 

--- a/lib/r3x/workflow/base.rb
+++ b/lib/r3x/workflow/base.rb
@@ -23,6 +23,7 @@ module R3x
             workflow_class: self.class,
             trigger_key:,
             trigger_payload:,
+            active_job_id: job_id,
           )
           if initial_execution?
             logger.info "Running workflow trigger_type=#{ctx.trigger.type}"

--- a/lib/r3x/workflow/context.rb
+++ b/lib/r3x/workflow/context.rb
@@ -7,11 +7,11 @@ module R3x
 
       attr_reader :trigger, :execution, :workflow_class, :workflow_key
 
-      def initialize(trigger:, workflow_key:, workflow_class: nil)
+      def initialize(trigger:, workflow_key:, trigger_key: nil, active_job_id: nil, workflow_class: nil)
         @trigger = trigger
         @workflow_key = workflow_key
         @workflow_class = workflow_class
-        @execution = Execution.new(workflow_key:)
+        @execution = Execution.new(workflow_key:, trigger_key:, active_job_id:)
       end
 
       def client

--- a/lib/r3x/workflow/execution.rb
+++ b/lib/r3x/workflow/execution.rb
@@ -3,16 +3,18 @@
 module R3x
   module Workflow
     class Execution
-      attr_reader :workflow_key
+      attr_reader :workflow_key, :trigger_key, :active_job_id
 
-      def initialize(workflow_key:)
+      def initialize(workflow_key:, trigger_key: nil, active_job_id: nil)
         @workflow_key = workflow_key
+        @trigger_key = trigger_key
+        @active_job_id = active_job_id
       end
 
       def previous_run_at
         return @previous_run_at if defined?(@previous_run_at)
 
-        @previous_run_at = recurring_task&.last_enqueued_time
+        @previous_run_at = previous_recurring_run_at
       end
 
       def first_run?
@@ -21,10 +23,12 @@ module R3x
 
       private
 
-      def recurring_task
-        return @recurring_task if defined?(@recurring_task)
+      def previous_recurring_run_at
+        return if trigger_key.blank?
 
-        @recurring_task = SolidQueue::RecurringTask.find_by(key: @workflow_key)
+        ::Dashboard::RecurringTask
+          .find_by_workflow_and_trigger_key(workflow_key:, trigger_key:)
+          &.previous_run_at(active_job_id:)
       end
     end
   end

--- a/lib/r3x/workflow/executor.rb
+++ b/lib/r3x/workflow/executor.rb
@@ -7,27 +7,32 @@ module R3x
         new(...).build_context
       end
 
-      def initialize(workflow_class:, trigger_key:, trigger_payload: nil)
+      def initialize(workflow_class:, trigger_key:, trigger_payload: nil, active_job_id: nil)
         @workflow_class = workflow_class
         @trigger_key = trigger_key
         @trigger_payload = trigger_payload
+        @active_job_id = active_job_id
       end
 
       def build_context
+        trigger = resolve_trigger
+
         Context.new(
           trigger: TriggerManager::Execution.new(
-            trigger: resolve_trigger,
+            trigger:,
             workflow_key: workflow_class.workflow_key,
             payload: trigger_payload,
           ),
           workflow_key: workflow_class.workflow_key,
+          trigger_key: trigger.unique_key,
+          active_job_id:,
           workflow_class:,
         )
       end
 
       private
 
-      attr_reader :workflow_class, :trigger_key, :trigger_payload
+      attr_reader :workflow_class, :trigger_key, :trigger_payload, :active_job_id
 
       def resolve_trigger
         return manual_trigger if trigger_key.nil?

--- a/test/lib/r3x/workflow/context_test.rb
+++ b/test/lib/r3x/workflow/context_test.rb
@@ -5,42 +5,109 @@ require "test_helper"
 module R3x
   module Workflow
     class ExecutionTest < ActiveSupport::TestCase
+      setup do
+        TestDbCleanup.clear_runtime_tables!
+      end
+
+      teardown do
+        TestDbCleanup.clear_runtime_tables!
+      end
+
       test "previous_run_at returns nil when no execution in solid_queue" do
         execution = Execution.new(workflow_key: "nonexistent_workflow")
 
         assert_nil execution.previous_run_at
       end
 
-      test "previous_run_at is memoized" do
-        job = SolidQueue::Job.create!(
-          queue_name: "default",
-          class_name: R3x::TestSupport::DashboardWorkflowJob.name,
-          arguments: ["test_memo"],
-        )
+      test "previous_run_at finds production workflow recurring task key" do
+        task_key = "workflow:test_workflow:schedule:daily"
+        previous_run_at = 2.hours.ago.change(usec: 0)
+        job = create_workflow_job!(arguments: ["schedule:daily"])
         SolidQueue::RecurringTask.create!(
-          key: "test_memo",
+          key: task_key,
           schedule: "0 * * * *",
           class_name: R3x::TestSupport::DashboardWorkflowJob.name,
-          arguments: [],
+          arguments: ["schedule:daily"],
           queue_name: "default",
         )
         SolidQueue::RecurringExecution.create!(
-          task_key: "test_memo",
-          run_at: 2.hours.ago,
+          task_key:,
+          run_at: previous_run_at,
           job_id: job.id,
         )
 
-        execution = Execution.new(workflow_key: "test_memo")
+        execution = Execution.new(workflow_key: "test_workflow", trigger_key: "schedule:daily")
+
+        assert_equal previous_run_at, execution.previous_run_at
+      end
+
+      test "previous_run_at ignores the current recurring execution" do
+        task_key = "workflow:test_workflow:schedule:daily"
+        current_run_at = 1.hour.ago.change(usec: 0)
+        current_job = create_workflow_job!(arguments: ["schedule:daily"])
+        create_recurring_task!(task_key:, arguments: ["schedule:daily"])
+        SolidQueue::RecurringExecution.create!(
+          task_key:,
+          run_at: current_run_at,
+          job_id: current_job.id,
+        )
+
+        execution = Execution.new(
+          workflow_key: "test_workflow",
+          trigger_key: "schedule:daily",
+          active_job_id: current_job.active_job_id,
+        )
+
+        assert_nil execution.previous_run_at
+        assert_predicate execution, :first_run?
+      end
+
+      test "previous_run_at returns the previous recurring execution before the current job" do
+        task_key = "workflow:test_workflow:schedule:daily"
+        previous_run_at = 2.hours.ago.change(usec: 0)
+        current_run_at = 1.hour.ago.change(usec: 0)
+        previous_job = create_workflow_job!(arguments: ["schedule:daily"])
+        current_job = create_workflow_job!(arguments: ["schedule:daily"])
+        create_recurring_task!(task_key:, arguments: ["schedule:daily"])
+        SolidQueue::RecurringExecution.create!(
+          task_key:,
+          run_at: previous_run_at,
+          job_id: previous_job.id,
+        )
+        SolidQueue::RecurringExecution.create!(
+          task_key:,
+          run_at: current_run_at,
+          job_id: current_job.id,
+        )
+
+        execution = Execution.new(
+          workflow_key: "test_workflow",
+          trigger_key: "schedule:daily",
+          active_job_id: current_job.active_job_id,
+        )
+
+        assert_equal previous_run_at, execution.previous_run_at
+        assert_not_predicate execution, :first_run?
+      end
+
+      test "previous_run_at is memoized" do
+        task_key = "workflow:test_memo:schedule:memo"
+        previous_run_at = 2.hours.ago.change(usec: 0)
+        job = create_workflow_job!(arguments: ["schedule:memo"])
+        create_recurring_task!(task_key:, arguments: ["schedule:memo"])
+        SolidQueue::RecurringExecution.create!(
+          task_key:,
+          run_at: previous_run_at,
+          job_id: job.id,
+        )
+
+        execution = Execution.new(workflow_key: "test_memo", trigger_key: "schedule:memo")
 
         t1 = execution.previous_run_at
         t2 = execution.previous_run_at
 
         assert_equal t1, t2
-        assert_predicate t1, :present?
-      ensure
-        SolidQueue::RecurringExecution.where(task_key: "test_memo").delete_all
-        SolidQueue::RecurringTask.where(key: "test_memo").delete_all
-        SolidQueue::Job.where(class_name: R3x::TestSupport::DashboardWorkflowJob.name).delete_all
+        assert_equal previous_run_at, t1
       end
 
       test "first_run? returns true when no previous_run_at" do
@@ -50,31 +117,34 @@ module R3x
       end
 
       test "first_run? returns false when previous_run_at exists" do
-        job = SolidQueue::Job.create!(
-          queue_name: "default",
-          class_name: R3x::TestSupport::DashboardWorkflowJob.name,
-          arguments: ["test_fr"],
-        )
-        SolidQueue::RecurringTask.create!(
-          key: "test_fr",
-          schedule: "0 * * * *",
-          class_name: R3x::TestSupport::DashboardWorkflowJob.name,
-          arguments: [],
-          queue_name: "default",
-        )
+        task_key = "workflow:test_fr:schedule:first_run"
+        job = create_workflow_job!(arguments: ["schedule:first_run"])
+        create_recurring_task!(task_key:, arguments: ["schedule:first_run"])
         SolidQueue::RecurringExecution.create!(
-          task_key: "test_fr",
-          run_at: 2.hours.ago,
+          task_key:,
+          run_at: 2.hours.ago.change(usec: 0),
           job_id: job.id,
         )
 
-        execution = Execution.new(workflow_key: "test_fr")
+        execution = Execution.new(workflow_key: "test_fr", trigger_key: "schedule:first_run")
 
         assert_not_predicate execution, :first_run?
-      ensure
-        SolidQueue::RecurringExecution.where(task_key: "test_fr").delete_all
-        SolidQueue::RecurringTask.where(key: "test_fr").delete_all
-        SolidQueue::Job.where(class_name: R3x::TestSupport::DashboardWorkflowJob.name).delete_all
+      end
+
+      private
+
+      def create_workflow_job!(arguments:)
+        SolidQueue::Job.enqueue(R3x::TestSupport::DashboardWorkflowJob.new(*arguments))
+      end
+
+      def create_recurring_task!(task_key:, arguments:)
+        SolidQueue::RecurringTask.create!(
+          key: task_key,
+          schedule: "0 * * * *",
+          class_name: R3x::TestSupport::DashboardWorkflowJob.name,
+          arguments:,
+          queue_name: "default",
+        )
       end
     end
 
@@ -252,8 +322,6 @@ module R3x
           assert_equal "go-test-key", context.config.opencode_go_api_key
         end
       end
-
-
 
       private
 


### PR DESCRIPTION
## Summary

Fix scheduled workflow `previous_run_at` so the current Solid Queue recurring execution is not reported as the previous run. This restores first-run semantics and keeps Solid Queue reads behind the dashboard boundary.

## Changes

- Pass the current Active Job id through workflow context/execution.
- Resolve recurring tasks by `workflow:<workflow_key>:<trigger_key>` and exclude the current job when calculating `previous_run_at`.
- Add regression tests using real `SolidQueue::Job.enqueue` job ids.
- Update `docs/todo.md` for the completed Solid Queue boundary fix.

## Testing

- `R3X_SKIP_VAULT_ENV_LOAD=true bin/rails test test/lib/r3x/workflow/context_test.rb test/lib/r3x/dashboard/recurring_task_test.rb`
- `XDG_CACHE_HOME=/tmp/r3x-ci-cache RUBOCOP_CACHE_ROOT=/tmp/r3x-rubocop-cache R3X_SKIP_VAULT_ENV_LOAD=true bin/ci`
- Commit hook `bin/ci` passed: 576 runs, 1664 assertions, 0 failures.