### PR TITLE
Bound previous run lookup to current slot

### DIFF
--- a/app/models/dashboard/recurring_task.rb
+++ b/app/models/dashboard/recurring_task.rb
@@ -46,7 +46,10 @@ module Dashboard
 
     def previous_run_at(active_job_id: nil)
       executions = SolidQueue::RecurringExecution.where(task_key: key)
-      executions = executions.joins(:job).where.not(SolidQueue::Job.table_name => { active_job_id: }) if active_job_id.present?
+      if active_job_id.present?
+        current_run_at = executions.joins(:job).where(SolidQueue::Job.table_name => { active_job_id: }).pick(:run_at)
+        executions = executions.where("run_at < ?", current_run_at) if current_run_at
+      end
       executions.maximum(:run_at)
     end
 

--- a/test/lib/r3x/workflow/context_test.rb
+++ b/test/lib/r3x/workflow/context_test.rb
@@ -90,6 +90,68 @@ module R3x
         assert_not_predicate execution, :first_run?
       end
 
+      test "previous_run_at ignores later recurring executions when current job is delayed" do
+        task_key = "workflow:test_workflow:schedule:daily"
+        previous_run_at = 3.hours.ago.change(usec: 0)
+        current_run_at = 2.hours.ago.change(usec: 0)
+        later_run_at = 1.hour.ago.change(usec: 0)
+        previous_job = create_workflow_job!(arguments: ["schedule:daily"])
+        current_job = create_workflow_job!(arguments: ["schedule:daily"])
+        later_job = create_workflow_job!(arguments: ["schedule:daily"])
+        create_recurring_task!(task_key:, arguments: ["schedule:daily"])
+        SolidQueue::RecurringExecution.create!(
+          task_key:,
+          run_at: previous_run_at,
+          job_id: previous_job.id,
+        )
+        SolidQueue::RecurringExecution.create!(
+          task_key:,
+          run_at: current_run_at,
+          job_id: current_job.id,
+        )
+        SolidQueue::RecurringExecution.create!(
+          task_key:,
+          run_at: later_run_at,
+          job_id: later_job.id,
+        )
+
+        execution = Execution.new(
+          workflow_key: "test_workflow",
+          trigger_key: "schedule:daily",
+          active_job_id: current_job.active_job_id,
+        )
+
+        assert_equal previous_run_at, execution.previous_run_at
+      end
+
+      test "first_run? ignores later recurring executions when first job is delayed" do
+        task_key = "workflow:test_workflow:schedule:daily"
+        current_run_at = 2.hours.ago.change(usec: 0)
+        later_run_at = 1.hour.ago.change(usec: 0)
+        current_job = create_workflow_job!(arguments: ["schedule:daily"])
+        later_job = create_workflow_job!(arguments: ["schedule:daily"])
+        create_recurring_task!(task_key:, arguments: ["schedule:daily"])
+        SolidQueue::RecurringExecution.create!(
+          task_key:,
+          run_at: current_run_at,
+          job_id: current_job.id,
+        )
+        SolidQueue::RecurringExecution.create!(
+          task_key:,
+          run_at: later_run_at,
+          job_id: later_job.id,
+        )
+
+        execution = Execution.new(
+          workflow_key: "test_workflow",
+          trigger_key: "schedule:daily",
+          active_job_id: current_job.active_job_id,
+        )
+
+        assert_nil execution.previous_run_at
+        assert_predicate execution, :first_run?
+      end
+
       test "previous_run_at is memoized" do
         task_key = "workflow:test_memo:schedule:memo"
         previous_run_at = 2.hours.ago.change(usec: 0)


### PR DESCRIPTION
## Summary

Follow-up to #78. Bounds scheduled workflow `previous_run_at` to recurring executions before the current scheduled slot, so delayed jobs do not see later queued slots as their previous run.

Addresses Codex review comment: https://github.com/r3x-dev/engine/pull/78#discussion_r3444199263

## Changes

- Locate the current recurring execution `run_at` from the current Active Job id.
- Calculate `previous_run_at` from executions with `run_at` before that current slot.
- Add regression coverage for delayed jobs with later recurring executions already recorded, including first-run semantics.

## Testing

- `R3X_SKIP_VAULT_ENV_LOAD=true bin/rails test test/lib/r3x/workflow/context_test.rb test/lib/r3x/dashboard/recurring_task_test.rb`
- `XDG_CACHE_HOME=/tmp/r3x-ci-cache RUBOCOP_CACHE_ROOT=/tmp/r3x-rubocop-cache R3X_SKIP_VAULT_ENV_LOAD=true bin/ci`
- Commit hook `bin/ci` passed: 578 runs, 1668 assertions, 0 failures.