### PR TITLE
Extract and normalize workflow run error details

### DIFF
--- a/app/lib/r3x/dashboard/error_details.rb
+++ b/app/lib/r3x/dashboard/error_details.rb
@@ -3,119 +3,29 @@
 module R3x
   module Dashboard
     class ErrorDetails
-      ERROR_KEYS = %w[exception_class error_class message error backtrace trace stack].freeze
-
       def initialize(error)
-        @error = error
+        @details = R3x::ErrorDetails.new(error)
       end
 
       def summary
-        summary = if error.is_a?(Hash)
-          parsed_error["message"] || parsed_error["error"] || error.inspect
-        else
-          extract_error_message(error.to_s)
-        end
-
-        summary.presence || "Unknown error"
+        details.summary
       end
 
       def body
-        return "No error details recorded." if error.blank?
-
-        error.is_a?(Hash) ? error.inspect : error.to_s
+        details.body
       end
 
       def details_visible?
-        body.present? && summary != body
+        details.details_visible?
       end
 
       def structured
-        return if parsed_error.blank?
-
-        {
-          exception_class: parsed_error["exception_class"].presence || parsed_error["error_class"].presence,
-          message: parsed_error["message"].presence || parsed_error["error"].presence,
-          backtrace: Array(parsed_error["backtrace"] || parsed_error["trace"] || parsed_error["stack"]).compact_blank,
-        }.compact_blank
+        details.structured
       end
 
       private
 
-      attr_reader :error
-
-      def parsed_error
-        @parsed_error ||=
-          case error
-          when Hash
-            error.stringify_keys
-          else
-            parse_error_text(error.to_s) || {}
-          end
-      end
-
-      def extract_error_message(text)
-        first_line = text.lines.first.to_s.strip
-        return Regexp.last_match(1) if first_line =~ /"message"\s*=>\s*"([^"]+)"/
-        return Regexp.last_match(1) if first_line =~ /"message"\s*:\s*"([^"]+)"/
-
-        first_line
-      end
-
-      def parse_error_text(text)
-        return if text.blank?
-
-        parse_json_error_text(text) || parse_ruby_hash_error_text(text)
-      end
-
-      def parse_json_error_text(text)
-        return unless text.lstrip.start_with?("{", "[")
-
-        parsed = MultiJSON.parse(text)
-        parsed.is_a?(Hash) ? parsed.stringify_keys : nil
-      rescue MultiJSON::ParseError
-        nil
-      end
-
-      def parse_ruby_hash_error_text(text)
-        return unless text.include?("=>")
-
-        {
-          "exception_class" => extract_ruby_hash_error_value(text, "exception_class"),
-          "message"         => extract_ruby_hash_error_value(text, "message"),
-          "backtrace"       => extract_ruby_hash_error_array(text, "backtrace"),
-        }.compact_blank
-      end
-
-      def extract_ruby_hash_error_value(text, key)
-        pattern = /
-          "#{Regexp.escape(key)}"\s*(?:=>|:)\s*"(?<value>.*?)"\s*
-          (?=,\s*"(?:#{ERROR_KEYS.join("|")})"\s*(?:=>|:)|\s*}\z)
-        /mx
-        match = text.match(pattern)
-        return unless match
-
-        unescape_error_string(match[:value])
-      end
-
-      def extract_ruby_hash_error_array(text, key)
-        pattern = /
-          "#{Regexp.escape(key)}"\s*(?:=>|:)\s*\[(?<value>.*?)\]\s*
-          (?=,\s*"(?:#{ERROR_KEYS.join("|")})"\s*(?:=>|:)|\s*}\z)
-        /mx
-        match = text.match(pattern)
-        return [] unless match
-
-        match[:value]
-          .scan(/"((?:[^"\\]|\\.)*)"/)
-          .flatten
-          .map { |value| unescape_error_string(value) }
-      end
-
-      def unescape_error_string(value)
-        MultiJSON.parse(%("#{value}"))
-      rescue MultiJSON::ParseError
-        value.to_s.gsub('\"', '"').gsub("\\\\", "\\")
-      end
+      attr_reader :details
     end
   end
 end

--- a/app/lib/r3x/dashboard/logs.rb
+++ b/app/lib/r3x/dashboard/logs.rb
@@ -43,7 +43,7 @@ module R3x
 
       def build_query(filter)
         "(#{filter}) | fields _time, kubernetes.pod_name, kubernetes.container_name, " \
-          "_msg, level, tags, error_class, error_message, backtrace"
+          "_msg, level, tags, error_class, error_message, backtrace, exception_class, error, trace, stack"
       end
 
       def error_logs(provider, error)
@@ -97,11 +97,12 @@ module R3x
       def parse_message_payload(entry, context: {})
         if entry.key?("level")
           message, tags = extract_message_and_tags(entry["_msg"], tags: normalize_array_field(entry["tags"]), context:)
+          error = normalize_error_fields(entry)
 
           return {
-            backtrace: normalize_array_field(entry["backtrace"]).presence,
-            error_class: entry["error_class"],
-            error_message: entry["error_message"],
+            backtrace: error&.fetch(:backtrace, nil),
+            error_class: error&.fetch(:error_class, nil),
+            error_message: error&.fetch(:message, nil),
             level: normalize_level(entry["level"]),
             message:,
             tags:,
@@ -123,11 +124,12 @@ module R3x
         end
 
         message, tags = extract_message_and_tags(payload["message"], tags: payload["tags"], context:)
+        error = normalize_error_fields(payload)
 
         {
-          backtrace: normalize_array_field(payload["backtrace"]).presence,
-          error_class: payload["error_class"],
-          error_message: payload["error_message"],
+          backtrace: error&.fetch(:backtrace, nil),
+          error_class: error&.fetch(:error_class, nil),
+          error_message: error&.fetch(:message, nil),
           level: normalize_level(payload["level"]),
           message:,
           tags:,
@@ -191,6 +193,21 @@ module R3x
         end
       rescue MultiJSON::ParseError
         [value]
+      end
+
+      def normalize_error_fields(fields)
+        raw_error = {
+          "error_class"   => fields["error_class"] || fields["exception_class"],
+          "error_message" => fields["error_message"],
+          "error"         => fields["error"],
+          "backtrace"     => normalize_array_field(fields["backtrace"]).presence,
+          "trace"         => normalize_array_field(fields["trace"]).presence,
+          "stack"         => normalize_array_field(fields["stack"]).presence,
+        }.compact_blank
+
+        return if raw_error.blank?
+
+        R3x::ErrorDetails.new(raw_error).structured
       end
 
       def unavailable_logs

--- a/app/lib/r3x/dashboard/logs.rb
+++ b/app/lib/r3x/dashboard/logs.rb
@@ -197,12 +197,13 @@ module R3x
 
       def normalize_error_fields(fields)
         raw_error = {
-          "error_class"   => fields["error_class"] || fields["exception_class"],
-          "error_message" => fields["error_message"],
-          "error"         => fields["error"],
-          "backtrace"     => normalize_array_field(fields["backtrace"]).presence,
-          "trace"         => normalize_array_field(fields["trace"]).presence,
-          "stack"         => normalize_array_field(fields["stack"]).presence,
+          "error_class"     => fields["error_class"],
+          "exception_class" => fields["exception_class"],
+          "error_message"   => fields["error_message"],
+          "error"           => fields["error"],
+          "backtrace"       => normalize_array_field(fields["backtrace"]).presence,
+          "trace"           => normalize_array_field(fields["trace"]).presence,
+          "stack"           => normalize_array_field(fields["stack"]).presence,
         }.compact_blank
 
         return if raw_error.blank?

--- a/app/lib/r3x/error_details.rb
+++ b/app/lib/r3x/error_details.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+module R3x
+  class ErrorDetails
+    ERROR_KEYS = %w[exception_class error_class error_message message error backtrace trace stack].freeze
+
+    attr_reader :error_class, :message, :backtrace
+
+    def initialize(error)
+      @error = error
+      @parsed_error = parse_error
+      @error_class = parsed_error["error_class"].presence || parsed_error["exception_class"].presence
+      @message = parsed_error["message"].presence || parsed_error["error_message"].presence || parsed_error["error"].presence
+      @backtrace = Array(parsed_error["backtrace"] || parsed_error["trace"] || parsed_error["stack"]).compact_blank.presence
+    end
+
+    def summary
+      message.presence || fallback_summary.presence || "Unknown error"
+    end
+
+    def body
+      return "No error details recorded." if error.blank?
+
+      error.is_a?(Exception) ? exception_body : error.to_s
+    end
+
+    def details_visible?
+      body.present? && summary != body
+    end
+
+    def structured
+      {
+        error_class:,
+        message:,
+        backtrace:,
+      }.compact_blank.presence
+    end
+
+    private
+
+    attr_reader :error, :parsed_error
+
+    def parse_error
+      case error
+      when Exception
+        {
+          "error_class" => error.class.name,
+          "message"     => error.message,
+          "backtrace"   => error.backtrace,
+        }
+      when Hash
+        error.stringify_keys
+      else
+        parse_error_text(error.to_s) || {}
+      end
+    end
+
+    def fallback_summary
+      case error
+      when Hash
+        error.inspect
+      else
+        first_line = error.to_s.lines.first.to_s.strip
+        extract_error_value(first_line, "message") || extract_error_value(first_line, "error_message") || first_line
+      end
+    end
+
+    def exception_body
+      lines = ["#{error.class.name}: #{error.message}", *Array(error.backtrace)].compact_blank
+      lines.join("\n")
+    end
+
+    def parse_error_text(text)
+      return if text.blank?
+
+      parse_json_error_text(text) || parse_ruby_hash_error_text(text)
+    end
+
+    def parse_json_error_text(text)
+      return unless text.lstrip.start_with?("{", "[")
+
+      parsed = MultiJSON.parse(text)
+      parsed.is_a?(Hash) ? parsed.stringify_keys : nil
+    rescue MultiJSON::ParseError
+      nil
+    end
+
+    def parse_ruby_hash_error_text(text)
+      return unless text.include?("=>")
+
+      ERROR_KEYS.index_with { |key| extract_ruby_hash_error_value(text, key) }
+        .merge(
+          "backtrace" => extract_ruby_hash_error_array(text, "backtrace"),
+          "trace"     => extract_ruby_hash_error_array(text, "trace"),
+          "stack"     => extract_ruby_hash_error_array(text, "stack"),
+        ).compact_blank
+    end
+
+    def extract_error_value(text, key)
+      pattern = /"#{Regexp.escape(key)}"\s*(?:=>|:)\s*"([^"]+)"/
+      match = text.match(pattern)
+      match && unescape_error_string(match[1])
+    end
+
+    def extract_ruby_hash_error_value(text, key)
+      pattern = /
+        "#{Regexp.escape(key)}"\s*(?:=>|:)\s*"(?<value>.*?)"\s*
+        (?=,\s*"(?:#{ERROR_KEYS.join("|")})"\s*(?:=>|:)|\s*}\z)
+      /mx
+      match = text.match(pattern)
+      return unless match
+
+      unescape_error_string(match[:value])
+    end
+
+    def extract_ruby_hash_error_array(text, key)
+      pattern = /
+        "#{Regexp.escape(key)}"\s*(?:=>|:)\s*\[(?<value>.*?)\]\s*
+        (?=,\s*"(?:#{ERROR_KEYS.join("|")})"\s*(?:=>|:)|\s*}\z)
+      /mx
+      match = text.match(pattern)
+      return [] unless match
+
+      match[:value]
+        .scan(/"((?:[^"\\]|\\.)*)"/)
+        .flatten
+        .map { |value| unescape_error_string(value) }
+    end
+
+    def unescape_error_string(value)
+      MultiJSON.parse(%("#{value}"))
+    rescue MultiJSON::ParseError
+      value.to_s.gsub('\"', '"').gsub("\\\\", "\\")
+    end
+  end
+end

--- a/app/lib/r3x/structured_logging.rb
+++ b/app/lib/r3x/structured_logging.rb
@@ -3,20 +3,22 @@
 module R3x
   module StructuredLogging
     def structured_error(message:, error:)
+      details = R3x::ErrorDetails.new(error)
+
       if R3x::Log.json?
         payload = {
           level: "error",
           time: Time.current.utc.iso8601(6),
           message:,
-          error_class: error.class.name,
-          error_message: error.message,
-          backtrace: error.backtrace&.first(20),
+          error_class: details.error_class,
+          error_message: details.message,
+          backtrace: details.backtrace&.first(20),
           tags: current_log_tags,
         }
         formatted = R3x::Log::JsonFormatter.new.call("error", Time.current, nil, payload)
         Rails.logger << formatted
       else
-        logger.error "#{message} error_class=#{error.class} error_message=#{error.message}"
+        logger.error "#{message} error_class=#{details.error_class} error_message=#{details.message}"
       end
     end
 

--- a/app/views/r3x/dashboard/overview/index.html.erb
+++ b/app/views/r3x/dashboard/overview/index.html.erb
@@ -44,8 +44,8 @@
             <% if error.present? %>
               <section class="failure-summary overview-error-panel">
                 <div class="overview-error-header">
-                  <% if error[:exception_class].present? %>
-                    <%= dashboard_pill(error[:exception_class], "danger") %>
+                  <% if error[:error_class].present? %>
+                    <%= dashboard_pill(error[:error_class], "danger") %>
                   <% end %>
                 </div>
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -109,9 +109,10 @@ view helper setup.
 - Keep helper methods focused on formatting parsed data for views.
 - Move existing structured-error assertions to detail-level tests where possible.
 
-**Done:** Regex-heavy error details now live in `R3x::Dashboard::ErrorDetails`.
-Dashboard helpers delegate to it and keep only view formatting concerns such as
-truncation.
+**Done:** Regex-heavy error details now live in shared `R3x::ErrorDetails`.
+Structured logging, dashboard log normalization, and dashboard helpers use it so
+`error_class`, `message`, and `backtrace` stay aligned. `R3x::Dashboard::ErrorDetails`
+remains a small dashboard-facing wrapper for display behavior.
 
 ---
 

--- a/test/lib/r3x/dashboard/error_details_test.rb
+++ b/test/lib/r3x/dashboard/error_details_test.rb
@@ -5,12 +5,12 @@ require "test_helper"
 module R3x
   module Dashboard
     class ErrorDetailsTest < ActiveSupport::TestCase
-      test "summarizes hash errors from message or error keys" do
+      test "delegates summaries for hash errors from message or error keys" do
         assert_equal "boom", ErrorDetails.new({ "message" => "boom" }).summary
         assert_equal "bad", ErrorDetails.new({ error: "bad" }).summary
       end
 
-      test "summarizes plain text errors from the first line" do
+      test "keeps legacy plain text display behavior" do
         details = ErrorDetails.new("boom\nfull details")
 
         assert_equal "boom", details.summary
@@ -18,13 +18,13 @@ module R3x
         assert_predicate details, :details_visible?
       end
 
-      test "summarizes inline JSON message values" do
+      test "delegates inline JSON message summaries" do
         details = ErrorDetails.new('{"message":"the server responded with status 403"}')
 
         assert_equal "the server responded with status 403", details.summary
       end
 
-      test "parses JSON error text into structured error data" do
+      test "delegates JSON error text into structured error data" do
         error = ErrorDetails.new(
           MultiJSON.generate(
             exception_class: "HTTPX::HTTPError",
@@ -33,17 +33,17 @@ module R3x
           ),
         ).structured
 
-        assert_equal "HTTPX::HTTPError", error[:exception_class]
+        assert_equal "HTTPX::HTTPError", error[:error_class]
         assert_equal "the server responded with status 403", error[:message]
         assert_equal ["line one", "line two"], error[:backtrace]
       end
 
-      test "parses ruby hash dumps into structured error data" do
+      test "delegates ruby hash dumps into structured error data" do
         error = ErrorDetails.new(
           '{"exception_class" => "HTTPX::HTTPError", "message" => "the server responded with status 403", "backtrace" => ["line one", "line two"]}',
         ).structured
 
-        assert_equal "HTTPX::HTTPError", error[:exception_class]
+        assert_equal "HTTPX::HTTPError", error[:error_class]
         assert_equal "the server responded with status 403", error[:message]
         assert_equal ["line one", "line two"], error[:backtrace]
       end

--- a/test/lib/r3x/dashboard/logs_test.rb
+++ b/test/lib/r3x/dashboard/logs_test.rb
@@ -84,6 +84,8 @@ module R3x
         assert_equal 1, result[:entries].size
         assert_includes client.calls.first[:query], 'tags:"r3x.run_active_job_id=aj-123"'
         assert_not_includes client.calls.first[:query], '_msg:"r3x.run_active_job_id=aj-123"'
+        assert_includes client.calls.first[:query], "exception_class"
+        assert_includes client.calls.first[:query], "trace"
       end
 
       test "run logs read collector-extracted structured fields" do
@@ -127,6 +129,38 @@ module R3x
             "error_class"               => "NameError",
             "error_message"             => "uninitialized constant",
             "backtrace"                 => ["app/lib/a.rb:1", "app/lib/b.rb:2"],
+            "kubernetes.container_name" => "app",
+            "kubernetes.pod_name"       => "r3x-jobs-123",
+          },
+        ])
+
+        run = {
+          active_job_id: "aj-123",
+          enqueued_at: Time.zone.parse("2026-04-15T12:00:00Z"),
+          finished_at: Time.zone.parse("2026-04-15T12:00:30Z"),
+        }
+
+        Logs.stubs(logs_client: client)
+        result = Logs.run_logs(run)
+        entry = result[:entries].first
+
+        assert_equal "error", entry[:level]
+        assert_equal "Workflow run failed", entry[:message]
+        assert_equal "NameError", entry[:error_class]
+        assert_equal "uninitialized constant", entry[:error_message]
+        assert_equal ["app/lib/a.rb:1", "app/lib/b.rb:2"], entry[:backtrace]
+      end
+
+      test "run logs keep legacy extracted error fields from collector" do
+        client = FakeLogsClient.new(entries: [
+          {
+            "_time"                     => "2026-04-15T12:00:01Z",
+            "_msg"                      => "Workflow run failed",
+            "level"                     => "error",
+            "tags"                      => ["ActiveJob", "r3x.run_active_job_id=aj-123"],
+            "exception_class"           => "NameError",
+            "error"                     => "uninitialized constant",
+            "trace"                     => ["app/lib/a.rb:1", "app/lib/b.rb:2"],
             "kubernetes.container_name" => "app",
             "kubernetes.pod_name"       => "r3x-jobs-123",
           },
@@ -319,6 +353,63 @@ module R3x
         entry = result[:entries].first
 
         assert_equal "error", entry[:level]
+        assert_equal "Workflow run failed", entry[:message]
+        assert_equal "NameError", entry[:error_class]
+        assert_equal "uninitialized constant", entry[:error_message]
+        assert_equal ["app/lib/a.rb:1", "app/lib/b.rb:2"], entry[:backtrace]
+      end
+
+      test "does not treat ordinary log messages as error messages" do
+        client = FakeLogsClient.new(entries: [
+          {
+            "_time" => "2026-04-15T12:00:01Z",
+            "_msg"  => MultiJSON.generate(
+              "level"   => "error",
+              "message" => "Workflow run failed",
+            ),
+          },
+        ])
+
+        run = {
+          active_job_id: "aj-123",
+          enqueued_at: Time.zone.parse("2026-04-15T12:00:00Z"),
+          finished_at: Time.zone.parse("2026-04-15T12:00:30Z"),
+        }
+
+        Logs.stubs(logs_client: client)
+        result = Logs.run_logs(run)
+        entry = result[:entries].first
+
+        assert_equal "Workflow run failed", entry[:message]
+        assert_nil entry[:error_class]
+        assert_nil entry[:error_message]
+        assert_nil entry[:backtrace]
+      end
+
+      test "normalizes legacy structured error fields from hash payload" do
+        client = FakeLogsClient.new(entries: [
+          {
+            "_time" => "2026-04-15T12:00:01Z",
+            "_msg"  => MultiJSON.generate(
+              "level"           => "error",
+              "message"         => "Workflow run failed",
+              "exception_class" => "NameError",
+              "error"           => "uninitialized constant",
+              "trace"           => ["app/lib/a.rb:1", "app/lib/b.rb:2"],
+            ),
+          },
+        ])
+
+        run = {
+          active_job_id: "aj-123",
+          enqueued_at: Time.zone.parse("2026-04-15T12:00:00Z"),
+          finished_at: Time.zone.parse("2026-04-15T12:00:30Z"),
+        }
+
+        Logs.stubs(logs_client: client)
+        result = Logs.run_logs(run)
+        entry = result[:entries].first
+
         assert_equal "Workflow run failed", entry[:message]
         assert_equal "NameError", entry[:error_class]
         assert_equal "uninitialized constant", entry[:error_message]

--- a/test/lib/r3x/dashboard/logs_test.rb
+++ b/test/lib/r3x/dashboard/logs_test.rb
@@ -416,6 +416,35 @@ module R3x
         assert_equal ["app/lib/a.rb:1", "app/lib/b.rb:2"], entry[:backtrace]
       end
 
+      test "normalizes legacy exception_class when error_class is blank string" do
+        client = FakeLogsClient.new(entries: [
+          {
+            "_time" => "2026-04-15T12:00:01Z",
+            "_msg"  => MultiJSON.generate(
+              "level"           => "error",
+              "message"         => "Workflow run failed",
+              "error_class"     => "",
+              "exception_class" => "NameError",
+              "error"           => "uninitialized constant",
+            ),
+          },
+        ])
+
+        run = {
+          active_job_id: "aj-123",
+          enqueued_at: Time.zone.parse("2026-04-15T12:00:00Z"),
+          finished_at: Time.zone.parse("2026-04-15T12:00:30Z"),
+        }
+
+        Logs.stubs(logs_client: client)
+        result = Logs.run_logs(run)
+        entry = result[:entries].first
+
+        assert_equal "Workflow run failed", entry[:message]
+        assert_equal "NameError", entry[:error_class]
+        assert_equal "uninitialized constant", entry[:error_message]
+      end
+
       test "returns provider error when provider is unsupported" do
         Logs.stubs(provider_name: "unknown")
         result = Logs.run_logs(active_job_id: "aj-123")

--- a/test/lib/r3x/error_details_test.rb
+++ b/test/lib/r3x/error_details_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module R3x
+  class ErrorDetailsTest < ActiveSupport::TestCase
+    test "normalizes exceptions" do
+      exception = ArgumentError.new("boom")
+      exception.set_backtrace(["app/lib/a.rb:1", "app/lib/b.rb:2"])
+
+      details = ErrorDetails.new(exception)
+
+      assert_equal "ArgumentError", details.error_class
+      assert_equal "boom", details.message
+      assert_equal ["app/lib/a.rb:1", "app/lib/b.rb:2"], details.backtrace
+      assert_equal "boom", details.summary
+      assert_equal "ArgumentError: boom\napp/lib/a.rb:1\napp/lib/b.rb:2", details.body
+      assert_predicate details, :details_visible?
+      assert_equal(
+        { error_class: "ArgumentError", message: "boom", backtrace: ["app/lib/a.rb:1", "app/lib/b.rb:2"] },
+        details.structured,
+      )
+    end
+
+    test "normalizes canonical hash keys" do
+      details = ErrorDetails.new(
+        "error_class" => "NameError",
+        "message"     => "uninitialized constant",
+        "backtrace"   => ["app/lib/a.rb:1"],
+      )
+
+      assert_equal "NameError", details.error_class
+      assert_equal "uninitialized constant", details.message
+      assert_equal ["app/lib/a.rb:1"], details.backtrace
+      assert_equal(
+        { error_class: "NameError", message: "uninitialized constant", backtrace: ["app/lib/a.rb:1"] },
+        details.structured,
+      )
+    end
+
+    test "normalizes legacy hash keys" do
+      details = ErrorDetails.new(
+        exception_class: "HTTPX::HTTPError",
+        error_message: "forbidden",
+        trace: ["line one"],
+      )
+
+      assert_equal "HTTPX::HTTPError", details.error_class
+      assert_equal "forbidden", details.message
+      assert_equal ["line one"], details.backtrace
+    end
+
+    test "normalizes error and stack hash keys" do
+      details = ErrorDetails.new(error: "bad", stack: ["line one"])
+
+      assert_nil details.error_class
+      assert_equal "bad", details.message
+      assert_equal ["line one"], details.backtrace
+    end
+
+    test "normalizes json strings" do
+      details = ErrorDetails.new(
+        MultiJSON.generate(
+          exception_class: "HTTPX::HTTPError",
+          error_message: "forbidden",
+          trace: ["line one", "line two"],
+        ),
+      )
+
+      assert_equal(
+        { error_class: "HTTPX::HTTPError", message: "forbidden", backtrace: ["line one", "line two"] },
+        details.structured,
+      )
+    end
+
+    test "normalizes ruby hash dumps" do
+      details = ErrorDetails.new(
+        '{"exception_class" => "HTTPX::HTTPError", "error" => "forbidden", "stack" => ["line one", "line two"]}',
+      )
+
+      assert_equal(
+        { error_class: "HTTPX::HTTPError", message: "forbidden", backtrace: ["line one", "line two"] },
+        details.structured,
+      )
+    end
+
+    test "preserves plain text fallback behavior" do
+      details = ErrorDetails.new("boom\nfull details")
+
+      assert_equal "boom", details.summary
+      assert_equal "boom\nfull details", details.body
+      assert_predicate details, :details_visible?
+      assert_nil details.structured
+    end
+
+    test "preserves blank fallback behavior" do
+      details = ErrorDetails.new(nil)
+
+      assert_equal "Unknown error", details.summary
+      assert_equal "No error details recorded.", details.body
+      assert_nil details.structured
+    end
+  end
+end

--- a/test/lib/r3x/log_test.rb
+++ b/test/lib/r3x/log_test.rb
@@ -8,6 +8,10 @@ module R3x
       Log.instance_variable_set(:@format, nil)
     end
 
+    def teardown
+      Log.instance_variable_set(:@format, nil)
+    end
+
     test "defaults to plain when env is unset" do
       with_env("R3X_LOG_FORMAT" => nil) do
         assert_equal "plain", Log.format

--- a/test/lib/r3x/workflow_test.rb
+++ b/test/lib/r3x/workflow_test.rb
@@ -781,6 +781,15 @@ module R3x
       assert_includes output, "Workflow run failed"
       assert_match(/(?:"error_class":"ArgumentError"|error_class=ArgumentError)/, output)
       assert_match(/(?:"error_message":"boom"|error_message=boom)/, output)
+
+      failure_payload = output.lines
+        .map { |line| MultiJSON.parse(line) }
+        .find { |payload| payload["error_class"] == "ArgumentError" && payload["error_message"] == "boom" }
+
+      assert_equal "Workflow run failed", failure_payload.fetch("message")
+      assert_equal "ArgumentError", failure_payload.fetch("error_class")
+      assert_equal "boom", failure_payload.fetch("error_message")
+      assert_instance_of Array, failure_payload.fetch("backtrace")
     end
 
     test "prevents overriding perform method in subclasses" do


### PR DESCRIPTION
This PR extracts and normalizes workflow run error details, introducing a unified R3x::ErrorDetails class to handle exception normalization, legacy log format parsing, and JSON log structure. Additionally, it fixes a log format test pollution bug where R3x::LogTest setup was not reverted in a teardown hook.